### PR TITLE
Create source jar on package/install

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,20 @@
 
 
 	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+						  <goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
 		<pluginManagement>
 			<plugins>
 				<plugin>


### PR DESCRIPTION
Having source jars available provides better insights for developers.
