### PR TITLE
address encoding issue by using UTF-8

### DIFF
--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/SimpleCommonRulesRewriterFactory.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/SimpleCommonRulesRewriterFactory.java
@@ -26,7 +26,7 @@ public class SimpleCommonRulesRewriterFactory implements RewriterFactory {
      * 
      */
    public SimpleCommonRulesRewriterFactory(InputStream is, QuerqyParserFactory querqyParserFactory, boolean ignoreCase) throws IOException {
-      InputStreamReader reader = new InputStreamReader(is);
+      InputStreamReader reader = new InputStreamReader(is, "UTF-8");
       try {
          rules = new SimpleCommonRulesParser(reader, querqyParserFactory, ignoreCase).parse();
       } catch (RuleParseException e) {


### PR DESCRIPTION
Querqy rules are not working while using special characters like german umlaut.
