### PR TITLE
Fixes Locale issue when parsing predicates, fixes #80

### DIFF
--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/LineParser.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/LineParser.java
@@ -26,7 +26,8 @@ public class LineParser {
 
     static final char RAWQUERY = '*';
 
-    public static Object parse(String line, Input previousInput, QuerqyParserFactory querqyParserFactory) {
+    public static Object parse(final String line, final Input previousInput,
+                               final QuerqyParserFactory querqyParserFactory) {
 
 
         if (line.endsWith("=>")) {
@@ -40,7 +41,7 @@ public class LineParser {
             return new ValidationError("Missing input for instruction");
         }
 
-        String lcLine = line.toLowerCase().trim();
+        final String lcLine = line.toLowerCase(Locale.ROOT).trim();
 
         if (lcLine.startsWith(INSTR_DELETE)) {
 
@@ -58,14 +59,14 @@ public class LineParser {
             }
 
             instructionTerms = instructionTerms.substring(1).trim();
-            Object expr = parseTermExpression(instructionTerms);
+            final Object expr = parseTermExpression(instructionTerms);
             if (expr instanceof ValidationError) {
                 return new ValidationError("Cannot parse line: " + line + " : " + ((ValidationError) expr).getMessage());
             }
             @SuppressWarnings("unchecked")
-            List<Term> deleteTerms = (List<Term>) expr;
-            List<Term> inputTerms = previousInput.getInputTerms();
-            for (Term term : deleteTerms) {
+            final List<Term> deleteTerms = (List<Term>) expr;
+            final List<Term> inputTerms = previousInput.getInputTerms();
+            for (final Term term : deleteTerms) {
                 if (term.findFirstMatch(inputTerms) == null) {
                     return new ValidationError("Condition doesn't contain the term to delete: " + term);
                 }

--- a/querqy-for-lucene/pom.xml
+++ b/querqy-for-lucene/pom.xml
@@ -73,7 +73,7 @@
         <hamcrest.version>2.1</hamcrest.version>
         <mockito.version>2.27.0</mockito.version>
 
-        <querqy.core.version>3.5.1</querqy.core.version>
+        <querqy.core.version>3.6.0-SNAPSHOT</querqy.core.version>
         <lucene.version>8.1.0</lucene.version>
         <minidev.json-smart.version>2.3</minidev.json-smart.version>
         <commons.io.version>2.5</commons.io.version>

--- a/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/CriteriaSelectionDefaultsTest.java
+++ b/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/CriteriaSelectionDefaultsTest.java
@@ -222,7 +222,7 @@ public class CriteriaSelectionDefaultsTest extends SolrTestCaseJ4 {
         SolrQueryRequest req = req("q", "input5 input6",
                 DisMaxParams.QF, "f1",
                 DisMaxParams.MM, "1",
-                getFilterParamName(REWRITER_ID_3), "$[?('a' in @.tt)]",
+                getFilterParamName(REWRITER_ID_3), "$[?('a' IN @.tt)]",
                 "defType", "querqy",
                 "debugQuery", "true"
         );

--- a/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/CriteriaSelectionTest.java
+++ b/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/CriteriaSelectionTest.java
@@ -240,7 +240,7 @@ public class CriteriaSelectionTest extends SolrTestCaseJ4 {
                 DisMaxParams.QF, "f1",
                 DisMaxParams.MM, "1",
                 getStrategyParamName(REWRITER_ID_3), "criteria",
-                getFilterParamName(REWRITER_ID_3), "$[?('a' in @.tt)]",
+                getFilterParamName(REWRITER_ID_3), "$[?('a' IN @.tt)]",
                 "defType", "querqy",
                 "debugQuery", "true"
         );


### PR DESCRIPTION
Fixed by passing Locale.ROOT when lowercasing predicates for comparison in `querqy.rewrite.commonrules.LineParser`.

JsonPath has a similar issue that made some of our Solr tests fail for the Turkish Locale, i.e. when using `in` in a JsonPath filter expression. I changed the tests to use `IN` in the filters. I also submitted a PR to JsonPath (https://github.com/json-path/JsonPath/pull/601)