### PR TITLE
issue104: Changing how RankQueries are applied to Solr's ResponseBuilder

### DIFF
--- a/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/LuceneQueries.java
+++ b/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/LuceneQueries.java
@@ -27,9 +27,4 @@ public class LuceneQueries {
         this.areQueriesInterdependent = areQueriesInterdependent;
         this.isMainQueryBoosted = isMainQueryBoosted;
     }
-
-    public LuceneQueries(final Query mainQuery, final List<Query> filterQueries, final Query userQuery,
-                         final boolean areQueriesInterdependent, final boolean isMainQueryBoosted) {
-        this(mainQuery, filterQueries, null, userQuery, null, areQueriesInterdependent, isMainQueryBoosted);
-    }
 }

--- a/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/QueryParsingController.java
+++ b/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/QueryParsingController.java
@@ -262,6 +262,7 @@ public class QueryParsingController {
 
         LuceneQueries luceneQueries;
         if ((!addQuerqyBoostQueriesToMainQuery) && hasQuerqyBoostQueries) {
+            // boost queries have not been applied to the main query, they are returned separately here, external rank queries are ignored
             luceneQueries = new LuceneQueries(mainQuery, filterQueries, querqyBoostQueries, userQuery, null, dfc != null,
                     false);
         } else {

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyDismaxQParser.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyDismaxQParser.java
@@ -4,6 +4,7 @@ import static org.apache.solr.common.SolrException.ErrorCode.*;
 
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.CommonParams;
@@ -27,6 +28,7 @@ import querqy.infologging.InfoLogging;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 public class QuerqyDismaxQParser extends QParser {
 
@@ -80,27 +82,7 @@ public class QuerqyDismaxQParser extends QParser {
 
             luceneQueries = controller.process();
 
-            if (luceneQueries.querqyBoostQueries != null && luceneQueries.querqyBoostQueries.size() > 0) {
-                // add as rerank query
-                final BooleanQuery.Builder builder = new BooleanQuery.Builder();
-
-                for (final Query q : luceneQueries.querqyBoostQueries) {
-                    builder.add(q, BooleanClause.Occur.SHOULD);
-                }
-
-                processedQuery = new QuerqyReRankQuery(maybeWrapQuery(luceneQueries.mainQuery),
-                        maybeWrapQuery(builder.build()), requestAdapter.getReRankNumDocs(), 1.0);
-
-            } else {
-                // an external rank query (parsed from querqy.rq) is only applied if no querqy boost queries have been applied
-                // (either by applying them on the main query as optional clauses or by wrapping the main query in a QuerqyReRankQuery)
-                if (luceneQueries.rankQuery != null && !luceneQueries.isMainQueryBoosted) {
-                    processedQuery = ((RankQuery) luceneQueries.rankQuery).wrap(luceneQueries.mainQuery);
-                } else {
-                    processedQuery = maybeWrapQuery(luceneQueries.mainQuery);
-                }
-            }
-
+            processedQuery = maybeWrapQuery(luceneQueries.mainQuery);
 
         } catch (final LuceneSearchEngineRequestAdapter.SyntaxException e) {
             throw new SyntaxError("Syntax error", e);
@@ -193,5 +175,28 @@ public class QuerqyDismaxQParser extends QParser {
 
     public List<Query> getFilterQueries() {
         return luceneQueries == null ? null : luceneQueries.filterQueries;
+    }
+
+    public Optional<RankQuery> getRankQuery() {
+        // there are two cases this QParser returns a RankQuery here:
+        //   1) the parsed query contains boosts and querqy.solr.QuerqyDismaxParams.QBOOST_METHOD is set to "rerank", or
+        //   2) a rank query was supplied via parameter querqy.rq and there is no boosting already on the main query
+        if (luceneQueries.querqyBoostQueries != null && luceneQueries.querqyBoostQueries.size() > 0) {
+            final BooleanQuery.Builder builder = new BooleanQuery.Builder();
+
+            for (final Query q : luceneQueries.querqyBoostQueries) {
+                builder.add(q, BooleanClause.Occur.SHOULD);
+            }
+
+            return Optional.of(new QuerqyReRankQuery(new MatchAllDocsQuery(), maybeWrapQuery(builder.build()),
+                    requestAdapter.getReRankNumDocs(), 1.0));
+
+        } else if (luceneQueries.rankQuery != null && !luceneQueries.isMainQueryBoosted) {
+            // an external rank query (parsed from querqy.rq) is only applied if no querqy boost queries have been applied
+            // (either by applying them on the main query as optional clauses or by wrapping the main query in a QuerqyReRankQuery)
+            return Optional.of((RankQuery) luceneQueries.rankQuery);
+        }
+
+        return Optional.empty();
     }
 }

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyQueryComponent.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyQueryComponent.java
@@ -1,11 +1,12 @@
 /**
- * 
+ *
  */
 package querqy.solr;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.lucene.search.Query;
@@ -13,6 +14,7 @@ import org.apache.solr.handler.component.QueryComponent;
 import org.apache.solr.handler.component.ResponseBuilder;
 import org.apache.solr.search.QParser;
 
+import org.apache.solr.search.RankQuery;
 import querqy.infologging.InfoLoggingContext;
 import querqy.rewrite.SearchEngineRequestAdapter;
 import querqy.rewrite.commonrules.model.DecorateInstruction;
@@ -30,11 +32,11 @@ public class QuerqyQueryComponent extends QueryComponent {
     public void prepare(final ResponseBuilder rb) throws IOException {
 
         super.prepare(rb);
-        
+
         QParser parser = rb.getQparser();
-        
+
         if (parser instanceof QuerqyDismaxQParser) {
-        
+
             List<Query> filterQueries = ((QuerqyDismaxQParser) parser).getFilterQueries();
             if ((filterQueries != null) && !filterQueries.isEmpty()) {
                 List<Query> filters = rb.getFilters();
@@ -45,6 +47,11 @@ public class QuerqyQueryComponent extends QueryComponent {
                 }
             }
 
+            // add the RankQuery to the ResponseBuilder, only if it does not already contain one (set by Solr's rq parameter)
+            Optional<RankQuery> maybeRankQuery = ((QuerqyDismaxQParser) parser).getRankQuery();
+            if (rb.getRankQuery() == null) {
+                maybeRankQuery.ifPresent(rb::setRankQuery);
+            }
         }
     }
 
@@ -53,11 +60,11 @@ public class QuerqyQueryComponent extends QueryComponent {
      */
     @Override
     public void process(final ResponseBuilder rb) throws IOException {
-        
+
         super.process(rb);
-        
+
         final QParser parser = rb.getQparser();
-        
+
         if (parser instanceof QuerqyDismaxQParser) {
 
             final SearchEngineRequestAdapter searchEngineRequestAdapter =

--- a/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/ExternalReRankerHandlingTest.java
+++ b/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/ExternalReRankerHandlingTest.java
@@ -16,6 +16,12 @@ import org.junit.Test;
 @SolrTestCaseJ4.SuppressSSL
 public class ExternalReRankerHandlingTest extends SolrTestCaseJ4 {
 
+    // org.apache.lucene.search.QueryRescorer#explain adds re-scorer classname in description
+    private static final String ASSERT_NO_RERANK_APPLIED = "//lst[@name='explain']/str[not(contains(.,'ReRank'))]";
+    private static final String ASSERT_SOLR_RERANK_APPLIED = "//lst[@name='explain']/str[contains(.,'solr.search.ReRankQParserPlugin$ReRankQueryRescorer')]";
+    private static final String ASSERT_NO_QUERQY_RERANK_APPLIED = "//lst[@name='explain']/str[not(contains(.,'QuerqyReRankQuery'))]";
+    private static final String ASSERT_QUERQY_RERANK_APPLIED = "//lst[@name='explain']/str[contains(.,'QuerqyReRankQuery')]";
+
     @BeforeClass
     public static void beforeTests() throws Exception {
         initCore("solrconfig-commonrules.xml", "schema.xml");
@@ -40,7 +46,8 @@ public class ExternalReRankerHandlingTest extends SolrTestCaseJ4 {
                 DisMaxParams.QF, "f1 f2",
                 "defType", "querqy",
                 "tie", "1",
-                "sort", "score DESC, id ASC");
+                "sort", "score DESC, id ASC",
+                "debug", "true");
 
         // same as above but with Solr rq/rqq reranking
         SolrQueryRequest reqReRanking = req("q", q,
@@ -49,14 +56,16 @@ public class ExternalReRankerHandlingTest extends SolrTestCaseJ4 {
                 "tie", "1",
                 "sort", "score DESC, id ASC",
                 "rq", "{!rerank reRankQuery=$rqq reRankDocs=2 reRankWeight=100}",
-                "rqq", "f1:a");
+                "rqq", "f1:a",
+                "debug", "true");
 
         // doc 2 gets a better as query matches in two fields and tie = 1
         assertQ("Result should be sorted by doc with more matches",
                 reqWithoutReRanking,
                 "//result[@name='response'][@numFound='2']",
                 "//doc[1]/str[@name='id'][text()='2']",
-                "//doc[2]/str[@name='id'][text()='1']");
+                "//doc[2]/str[@name='id'][text()='1']",
+                ASSERT_NO_RERANK_APPLIED);
 
 
         // doc 1 wins as it is reranked by rqq=a
@@ -64,7 +73,8 @@ public class ExternalReRankerHandlingTest extends SolrTestCaseJ4 {
                 reqReRanking,
                 "//result[@name='response'][@numFound='2']",
                 "//doc[1]/str[@name='id'][text()='1']",
-                "//doc[2]/str[@name='id'][text()='2']");
+                "//doc[2]/str[@name='id'][text()='2']",
+                ASSERT_SOLR_RERANK_APPLIED);
 
         reqWithoutReRanking.close();
         reqReRanking.close();
@@ -76,21 +86,23 @@ public class ExternalReRankerHandlingTest extends SolrTestCaseJ4 {
                 d("id", "2", "f1", "term b", "f2", "term"));
         String q = "term";
 
-        // same as with Solr's rerank processing, doc 1 wins despite doc2 having more matches
+        // same as with Solr's rerank parameter processing, doc 1 comes first despite doc2 having more matches
         SolrQueryRequest query = req("q", q,
                 DisMaxParams.QF, "f1 f2",
                 "defType", "querqy",
                 "tie", "1",
                 "sort", "score DESC, id ASC",
                 QRQ, "{!rerank reRankQuery=$rqq reRankDocs=2 reRankWeight=100}",
-                "rqq", "f1:a");
+                "rqq", "f1:a",
+                "debug", "true");
 
         // doc 1 wins as it is reranked by rqq=a
         assertQ("Result should be sorted with rerank query",
                 query,
                 "//result[@name='response'][@numFound='2']",
                 "//doc[1]/str[@name='id'][text()='1']",
-                "//doc[2]/str[@name='id'][text()='2']");
+                "//doc[2]/str[@name='id'][text()='2']",
+                ASSERT_SOLR_RERANK_APPLIED);
 
         query.close();
     }
@@ -122,7 +134,7 @@ public class ExternalReRankerHandlingTest extends SolrTestCaseJ4 {
                 "rqq", "f2:x");
 
         // same as above but with Querqy rq/rqq instead
-        SolrQueryRequest reqWithBoostOnMainQueryAndQuerqyReRanking = req("q", q,
+        SolrQueryRequest reqWithBoostOnMainQueryAndQuerqyReRankParameter = req("q", q,
                 DisMaxParams.QF, "f1 f2",
                 QueryParsing.OP, "OR",
                 "tie", "1",
@@ -132,7 +144,7 @@ public class ExternalReRankerHandlingTest extends SolrTestCaseJ4 {
                 "rqq", "f2:x");
 
         // boost added as QuerqyReRankQuery
-        SolrQueryRequest reqWithBoostAndRerankMethodAndNoReRanking = req("q", q,
+        SolrQueryRequest reqWithBoostAndRerankMethodAndNoReRankParameter = req("q", q,
                 DisMaxParams.QF, "f1 f2",
                 QueryParsing.OP, "OR",
                 "tie", "1",
@@ -142,7 +154,7 @@ public class ExternalReRankerHandlingTest extends SolrTestCaseJ4 {
                 "debugQuery", "true");
 
         // same as above but with Solr rq/rqq
-        SolrQueryRequest reqWithBoostAndRerankMethodAndSolrReRanking = req("q", q,
+        SolrQueryRequest reqWithBoostAndRerankMethodAndSolrReRankingParameter = req("q", q,
                 DisMaxParams.QF, "f1 f2",
                 QueryParsing.OP, "OR",
                 "tie", "1",
@@ -154,7 +166,7 @@ public class ExternalReRankerHandlingTest extends SolrTestCaseJ4 {
                 "rqq", "f2:x");
 
         // same as above but with Querqy rq/rqq
-        SolrQueryRequest reqWithBoostAndRerankMethodAndQuerqyReRanking = req("q", q,
+        SolrQueryRequest reqWithBoostAndRerankMethodAndQuerqyReRankParameter = req("q", q,
                 DisMaxParams.QF, "f1 f2",
                 QueryParsing.OP, "OR",
                 "tie", "1",
@@ -165,55 +177,57 @@ public class ExternalReRankerHandlingTest extends SolrTestCaseJ4 {
                 "querqy.rq", "{!rerank reRankQuery=$rqq reRankDocs=2 reRankWeight=100}",
                 "rqq", "f2:x");
 
-        assertQ("Result should be sorted by boosted term",
+        assertQ("Result should be sorted by boosted term by an additional SHOULD clause on the main query, not by reranking",
                 reqWithBoostOnMainQueryAndNoSolrReRanking,
                 "//result[@name='response'][@numFound='2']",
                 "//doc[1]/str[@name='id'][text()='2']",
                 "//doc[2]/str[@name='id'][text()='1']",
-                "//lst[@name='explain']/str[not(contains(.,'QuerqyReRankQuery'))]");
+                ASSERT_NO_RERANK_APPLIED);
 
         assertQ("Result should be sorted by external Solr reranking",
                 reqWithBoostOnMainQueryAndSolrReRanking,
                 "//result[@name='response'][@numFound='2']",
                 "//doc[1]/str[@name='id'][text()='1']",
                 "//doc[2]/str[@name='id'][text()='2']",
-                "//lst[@name='explain']/str[not(contains(.,'QuerqyReRankQuery'))]");
+                ASSERT_SOLR_RERANK_APPLIED,
+                ASSERT_NO_QUERQY_RERANK_APPLIED);
 
-        assertQ("Result should be sorted by boosted term",
-                reqWithBoostOnMainQueryAndQuerqyReRanking,
+        assertQ("Result should be sorted by boosted term by an additional SHOULD clause on the main query, rerank parameter being ignored",
+                reqWithBoostOnMainQueryAndQuerqyReRankParameter,
                 "//result[@name='response'][@numFound='2']",
                 "//doc[1]/str[@name='id'][text()='2']",
                 "//doc[2]/str[@name='id'][text()='1']",
-                "//lst[@name='explain']/str[not(contains(.,'QuerqyReRankQuery'))]");
+                ASSERT_NO_RERANK_APPLIED);
 
-        assertQ("Result should be sorted by boosted term",
-                reqWithBoostAndRerankMethodAndNoReRanking,
+        assertQ("Result should be sorted by boosted term by a Querqy rerank query",
+                reqWithBoostAndRerankMethodAndNoReRankParameter,
                 "//result[@name='response'][@numFound='2']",
                 "//doc[1]/str[@name='id'][text()='2']",
                 "//doc[2]/str[@name='id'][text()='1']",
-                "//lst[@name='explain']/str[contains(.,'QuerqyReRankQuery')]");
+                ASSERT_QUERQY_RERANK_APPLIED);
 
         assertQ("Result should be sorted by external Solr reranking",
-                reqWithBoostAndRerankMethodAndSolrReRanking,
+                reqWithBoostAndRerankMethodAndSolrReRankingParameter,
                 "//result[@name='response'][@numFound='2']",
                 "//doc[1]/str[@name='id'][text()='1']",
                 "//doc[2]/str[@name='id'][text()='2']",
-                "//lst[@name='explain']/str[contains(.,'QuerqyReRankQuery')]");
+                ASSERT_SOLR_RERANK_APPLIED,
+                ASSERT_NO_QUERQY_RERANK_APPLIED);
 
-        assertQ("Result should be sorted by boosted term",
-                reqWithBoostAndRerankMethodAndQuerqyReRanking,
+        assertQ("Result should be sorted by boosted term by external Querqy reranking",
+                reqWithBoostAndRerankMethodAndQuerqyReRankParameter,
                 "//result[@name='response'][@numFound='2']",
                 "//doc[1]/str[@name='id'][text()='2']",
                 "//doc[2]/str[@name='id'][text()='1']",
-                "//lst[@name='explain']/str[contains(.,'QuerqyReRankQuery')]");
+                ASSERT_QUERQY_RERANK_APPLIED);
 
         reqWithBoostOnMainQueryAndNoSolrReRanking.close();
         reqWithBoostOnMainQueryAndSolrReRanking.close();
-        reqWithBoostOnMainQueryAndQuerqyReRanking.close();
+        reqWithBoostOnMainQueryAndQuerqyReRankParameter.close();
 
-        reqWithBoostAndRerankMethodAndNoReRanking.close();
-        reqWithBoostAndRerankMethodAndSolrReRanking.close();
-        reqWithBoostAndRerankMethodAndQuerqyReRanking.close();
+        reqWithBoostAndRerankMethodAndNoReRankParameter.close();
+        reqWithBoostAndRerankMethodAndSolrReRankingParameter.close();
+        reqWithBoostAndRerankMethodAndQuerqyReRankParameter.close();
     }
 
     private void index(String[]... docs) {
@@ -226,4 +240,6 @@ public class ExternalReRankerHandlingTest extends SolrTestCaseJ4 {
     private static String[] d(String... strings) {
         return strings;
     }
+
+
 }


### PR DESCRIPTION
* No longer using a wrapped RankQuery as the main query for the ResponseBuilder#query
* Returning a possible RankQuery separately as ResponseBuilder#rankQuery.