### PR TITLE
LeafReader#terms possibly returning null in Collector Fixes #108

### DIFF
--- a/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/contrib/rewrite/wordbreak/Collector.java
+++ b/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/contrib/rewrite/wordbreak/Collector.java
@@ -262,41 +262,49 @@ public class Collector {
         for (final LeafReaderContext context : topReaderContext.leaves()) {
 
             final Terms terms1 = context.reader().terms(term1.field());
-            final Terms terms2 = context.reader().terms(term2.field());
 
-            final TermsEnum termsEnum1 = terms1.iterator();
-            if (!termsEnum1.seekExact(term1.bytes())) {
-                continue;
-            }
+            if (terms1 != null) {
 
-            final TermsEnum termsEnum2 = terms2.iterator();
-            if (!termsEnum2.seekExact(term2.bytes())) {
-                continue;
-            }
+                final Terms terms2 = context.reader().terms(term2.field());
+                if (terms2 != null) {
 
-            final PostingsEnum postings1 = termsEnum1.postings(null, PostingsEnum.NONE);
-            final PostingsEnum postings2 = termsEnum2.postings(null, PostingsEnum.NONE);
-
-            int doc1 = postings1.nextDoc();
-            while (doc1 != DocIdSetIterator.NO_MORE_DOCS) {
-                int doc2 = postings2.advance(doc1);
-                if (doc2 == DocIdSetIterator.NO_MORE_DOCS) {
-                    break;
-                }
-                if (doc2 == doc1) {
-                    count++;
-                    if (count >= minCount) {
-                        return true;
+                    final TermsEnum termsEnum1 = terms1.iterator();
+                    if (!termsEnum1.seekExact(term1.bytes())) {
+                        continue;
                     }
-                } else if (doc2 > doc1) {
-                    doc1 = postings1.advance(doc2);
-                    if (doc2 == doc1) {
-                        count++;
-                        if (count >= minCount) {
-                            return true;
+
+                    final TermsEnum termsEnum2 = terms2.iterator();
+                    if (!termsEnum2.seekExact(term2.bytes())) {
+                        continue;
+                    }
+
+                    final PostingsEnum postings1 = termsEnum1.postings(null, PostingsEnum.NONE);
+                    final PostingsEnum postings2 = termsEnum2.postings(null, PostingsEnum.NONE);
+
+                    int doc1 = postings1.nextDoc();
+                    while (doc1 != DocIdSetIterator.NO_MORE_DOCS) {
+                        int doc2 = postings2.advance(doc1);
+                        if (doc2 == DocIdSetIterator.NO_MORE_DOCS) {
+                            break;
+                        }
+                        if (doc2 == doc1) {
+                            count++;
+                            if (count >= minCount) {
+                                return true;
+                            }
+                        } else if (doc2 > doc1) {
+                            doc1 = postings1.advance(doc2);
+                            if (doc2 == doc1) {
+                                count++;
+                                if (count >= minCount) {
+                                    return true;
+                                }
+                            }
                         }
                     }
+
                 }
+
             }
 
         }

--- a/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/contrib/rewrite/wordbreak/GermanWordBreakerTest.java
+++ b/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/contrib/rewrite/wordbreak/GermanWordBreakerTest.java
@@ -21,6 +21,61 @@ import java.util.List;
 
 public class GermanWordBreakerTest extends LuceneTestCase {
 
+    @Test
+    public void testWithEmptyIndex() throws IOException {
+        final Analyzer analyzer = new WhitespaceAnalyzer();
+
+        final Directory directory = newDirectory();
+        final RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory, analyzer);
+
+        indexWriter.close();
+
+        try (final IndexReader indexReader = DirectoryReader.open(directory)) {
+
+            final MorphologicalWordBreaker wordBreaker = new MorphologicalWordBreaker(GERMAN, "f1", true, 1, 2, 100);
+            final List<CharSequence[]> sequences = wordBreaker.breakWord("abcdef", indexReader, 2, true);
+            assertNotNull(sequences);
+            assertTrue(sequences.isEmpty());
+
+        } finally {
+            try {
+                directory.close();
+            } catch (final IOException e) {
+                //
+            }
+        }
+
+    }
+
+    @Test
+    public void testWithNoExistentDictField() throws IOException {
+        final Analyzer analyzer = new WhitespaceAnalyzer();
+
+        final Directory directory = newDirectory();
+
+        final RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory, analyzer);
+        addNumDocsWithTextField("f1", "abc def", indexWriter, 4);
+        addNumDocsWithTextField("f1", "ab cdef", indexWriter, 10);
+        addNumDocsWithTextField("f1", "abcd ef", indexWriter, 5);
+
+        indexWriter.close();
+
+        try (final IndexReader indexReader = DirectoryReader.open(directory)) {
+
+            final MorphologicalWordBreaker wordBreaker = new MorphologicalWordBreaker(GERMAN, "f2", true, 1, 2, 100);
+            final List<CharSequence[]> sequences = wordBreaker.breakWord("abcdef", indexReader, 2, true);
+            assertNotNull(sequences);
+            assertTrue(sequences.isEmpty());
+
+        } finally {
+            try {
+                directory.close();
+            } catch (final IOException e) {
+                //
+            }
+        }
+
+    }
 
     @Test
     public void testNoLinkingMorpheme() throws IOException {


### PR DESCRIPTION
As it seems impossible to mock Lucene's IndexReaderContext, it seems I cannot test the case that LeafReader#terms returns null.

I'm still adding tests for an empty dictionary field, though LeafReader#terms doesn't return null in these cases.