### PR TITLE
Fix info logging for multi sharded environment

### DIFF
--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyQueryComponent.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyQueryComponent.java
@@ -10,8 +10,13 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.apache.lucene.search.Query;
+import org.apache.solr.client.solrj.SolrResponse;
+import org.apache.solr.common.util.NamedList;
 import org.apache.solr.handler.component.QueryComponent;
 import org.apache.solr.handler.component.ResponseBuilder;
+import org.apache.solr.handler.component.ShardRequest;
+import org.apache.solr.handler.component.ShardResponse;
+import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.search.QParser;
 
 import org.apache.solr.search.RankQuery;
@@ -19,11 +24,18 @@ import querqy.infologging.InfoLoggingContext;
 import querqy.rewrite.SearchEngineRequestAdapter;
 import querqy.rewrite.commonrules.model.DecorateInstruction;
 
+import static org.apache.solr.handler.component.ResponseBuilder.STAGE_EXECUTE_QUERY;
+import static querqy.solr.QuerqyDismaxParams.INFO_LOGGING;
+import static querqy.solr.ResponseSink.QUERQY_INFO_LOG;
+
 /**
  * @author René Kriegler, @renekrie
  *
  */
 public class QuerqyQueryComponent extends QueryComponent {
+
+    public static final String QUERQY_NAMED_DECORATIONS = "querqy_named_decorations";
+    public static final String QUERQY_DECORATIONS = "querqy_decorations";
 
     /* (non-Javadoc)
      * @see org.apache.solr.handler.component.SearchComponent#prepare(org.apache.solr.handler.component.ResponseBuilder)
@@ -73,18 +85,16 @@ public class QuerqyQueryComponent extends QueryComponent {
             final Map<String, Object> context = searchEngineRequestAdapter.getContext();
             if (context != null) {
 
-                @SuppressWarnings("unchecked")
-                final Set<Object> decorations = (Set<Object>) context.get(DecorateInstruction.DECORATION_CONTEXT_KEY);
+                @SuppressWarnings("unchecked") final Set<Object> decorations = (Set<Object>) context.get(DecorateInstruction.DECORATION_CONTEXT_KEY);
                 if (decorations != null) {
-                    rb.rsp.add("querqy_decorations", decorations);
+                    rb.rsp.add(QUERQY_DECORATIONS, decorations);
                 }
 
-                @SuppressWarnings("unchecked")
-                final Map<String, Object> namedDecorations =
+                @SuppressWarnings("unchecked") final Map<String, Object> namedDecorations =
                         (Map<String, Object>) context.get(DecorateInstruction.DECORATION_CONTEXT_MAP_KEY);
 
                 if (namedDecorations != null) {
-                    rb.rsp.add("querqy_named_decorations", namedDecorations);
+                    rb.rsp.add(QUERQY_NAMED_DECORATIONS, namedDecorations);
                 }
 
             }
@@ -102,4 +112,38 @@ public class QuerqyQueryComponent extends QueryComponent {
         return "Querqy search component";
     }
 
+    /**
+     * Collect all the debug information from the different shard requests.
+     */
+    @Override
+    public void handleResponses(ResponseBuilder rb, ShardRequest sreq) {
+        super.handleResponses(rb, sreq);
+
+        if (rb.stage != ResponseBuilder.STAGE_EXECUTE_QUERY) {
+            return;
+        }
+
+        List<ShardResponse> responses = sreq.responses;
+        if (!responses.isEmpty()) {
+            // We will receive from all shards the same info.
+            SolrResponse solrResponse = responses.get(0).getSolrResponse();
+            if (solrResponse != null) {
+
+                NamedList<Object> shardNamedListResponse = solrResponse.getResponse();
+
+                addShardRsp(shardNamedListResponse, rb.rsp, QUERQY_INFO_LOG);
+                addShardRsp(shardNamedListResponse, rb.rsp, QUERQY_DECORATIONS);
+                addShardRsp(shardNamedListResponse, rb.rsp, QUERQY_NAMED_DECORATIONS);
+            }
+        }
+    }
+
+    private static void addShardRsp(NamedList<Object> shardNamedListResponse, SolrQueryResponse rsp, String element) {
+        if (shardNamedListResponse != null) {
+            Object item = shardNamedListResponse.get(element);
+            if (item != null) {
+                rsp.add(element, item);
+            }
+        }
+    }
 }

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/ResponseSink.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/ResponseSink.java
@@ -1,6 +1,5 @@
 package querqy.solr;
 
-import org.apache.solr.common.util.NamedList;
 import org.apache.solr.request.SolrRequestInfo;
 import org.apache.solr.response.SolrQueryResponse;
 import querqy.infologging.Sink;
@@ -14,6 +13,7 @@ import java.util.TreeMap;
 public class ResponseSink implements Sink {
 
     private static final String CONTEXT_KEY = ResponseSink.class.getName() + ".MESSAGES";
+    public static final String QUERQY_INFO_LOG = "querqy.infoLog";
 
 
     @Override
@@ -37,7 +37,7 @@ public class ResponseSink implements Sink {
 
         if (messages != null && !messages.isEmpty()) {
             final SolrQueryResponse rsp = SolrRequestInfo.getRequestInfo().getRsp();
-            rsp.add("querqy.infoLog", messages);
+            rsp.add(QUERQY_INFO_LOG, messages);
         }
 
     }

--- a/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/QuerqyQueryComponentTest.java
+++ b/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/QuerqyQueryComponentTest.java
@@ -1,0 +1,108 @@
+package querqy.solr;
+
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.client.solrj.response.SolrResponseBase;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.handler.component.ResponseBuilder;
+import org.apache.solr.handler.component.ShardRequest;
+import org.apache.solr.handler.component.ShardResponse;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.request.SolrQueryRequestBase;
+import org.apache.solr.response.SolrQueryResponse;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.apache.solr.handler.component.ResponseBuilder.STAGE_DONE;
+import static org.apache.solr.handler.component.ResponseBuilder.STAGE_EXECUTE_QUERY;
+import static org.assertj.core.util.Lists.emptyList;
+import static querqy.solr.QuerqyQueryComponent.QUERQY_DECORATIONS;
+import static querqy.solr.QuerqyQueryComponent.QUERQY_NAMED_DECORATIONS;
+import static querqy.solr.ResponseSink.QUERQY_INFO_LOG;
+
+@SolrTestCaseJ4.SuppressSSL
+public class QuerqyQueryComponentTest extends SolrTestCaseJ4 {
+
+    private QuerqyQueryComponent component;
+    private SolrQueryRequest request;
+    private ResponseBuilder rb;
+    private NamedList<Object> namedList;
+    private ShardRequest shardRequest;
+
+    @BeforeClass
+    public static void beforeTests() throws Exception {
+        initCore("solrconfig-commonrules.xml", "schema.xml");
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        component = new QuerqyQueryComponent();
+        request = new SolrQueryRequestBase(h.getCore(), new ModifiableSolrParams()) {
+        };
+        rb = new ResponseBuilder(request, new SolrQueryResponse(), emptyList());
+        namedList = new NamedList<>();
+        shardRequest = new ShardRequest();
+
+        ShardResponse srsp = new ShardResponse();
+        SolrResponseBase shardQueryResponse = new SolrResponseBase();
+        shardQueryResponse.setResponse(namedList);
+        srsp.setSolrResponse(shardQueryResponse);
+        shardRequest.responses.add(srsp);
+    }
+
+    @Test
+    public void testIncorrectStage() {
+        rb.stage = STAGE_DONE;
+        namedList.add("foo", "bar");
+
+        component.handleResponses(rb, shardRequest);
+
+        assertNull(rb.rsp.getValues().get("foo"));
+    }
+
+    @Test
+    public void testCorrectStageButIncorrectKey() {
+        rb.stage = STAGE_EXECUTE_QUERY;
+        namedList.add("foo", "bar");
+
+        component.handleResponses(rb, shardRequest);
+
+        assertNull(rb.rsp.getValues().get("foo"));
+    }
+
+    @Test
+    public void testCorrectStage() {
+        rb.stage = STAGE_EXECUTE_QUERY;
+        namedList.add(QUERQY_INFO_LOG, "bar1");
+        namedList.add(QUERQY_DECORATIONS, "bar2");
+        namedList.add(QUERQY_NAMED_DECORATIONS, "bar3");
+
+        component.handleResponses(rb, shardRequest);
+
+        assertEquals("bar1", rb.rsp.getValues().get(QUERQY_INFO_LOG));
+        assertEquals("bar2", rb.rsp.getValues().get(QUERQY_DECORATIONS));
+        assertEquals("bar3", rb.rsp.getValues().get(QUERQY_NAMED_DECORATIONS));
+    }
+
+    @Test
+    public void testCorrectStageAndOnlyFirstIsValid() {
+        rb.stage = STAGE_EXECUTE_QUERY;
+        namedList.add(QUERQY_INFO_LOG, "bar1");
+
+        ShardResponse srsp2 = new ShardResponse();
+        SolrResponseBase rspb2 = new SolrResponseBase();
+        NamedList<Object> namedListSecondShard = new NamedList<>();
+        namedList.add(QUERQY_INFO_LOG, "bar2");
+        rspb2.setResponse(namedListSecondShard);
+        srsp2.setSolrResponse(rspb2);
+        shardRequest.responses.add(srsp2);
+
+        component.handleResponses(rb, shardRequest);
+
+        assertEquals(1, rb.rsp.getValues().size());
+        assertEquals("bar1", rb.rsp.getValues().get(QUERQY_INFO_LOG));
+    }
+}


### PR DESCRIPTION
In our cloud setup the infoLog is not part of the response, just from the single shards. By implementing the handleResponses function it's possible to collect these info and add them to the final response.
We also collect the _decorations_ and _named_decorations_ from the shard requests.