### PR TITLE
Use correct value in Term equals

### DIFF
--- a/querqy-core/src/main/java/querqy/model/Term.java
+++ b/querqy-core/src/main/java/querqy/model/Term.java
@@ -125,7 +125,7 @@ public class Term extends AbstractNode<DisjunctionMaxQuery> implements Disjuncti
          if (other.value != null) {
             return false;
          }
-      } else if (! CharSequenceUtil.equals(this, other.value)) {
+      } else if (! CharSequenceUtil.equals(value, other.value)) {
          return false;
       }
       return true;


### PR DESCRIPTION
This is a simple fix for the correct equals in Term. No change is expected, because the util function compares char by char. Therefore no tests added.