### PR TITLE
Add get all rewriter rest endpoint #76

### DIFF
--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyRewriterRequestHandler.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyRewriterRequestHandler.java
@@ -153,7 +153,18 @@ public class QuerqyRewriterRequestHandler implements SolrRequestHandler, NestedR
 
     @Override
     public void handleRequest(final SolrQueryRequest req, final SolrQueryResponse rsp) {
-
+        final Map<String, RewriterFactory> rewriters = rewriterContainer.rewriters;
+        try {
+            final Map<String, Object> result = new HashMap<>();
+            final Map<String, Map<String, Object>> rewritersResult = new HashMap<>();
+            for (String rewriterId : rewriters.keySet()) {
+                rewritersResult.put(rewriterId, rewriterContainer.readRewriterDescription(rewriterId));
+            }
+            result.put("rewriters", rewritersResult);
+            rsp.add("response", result);
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/RewriterConfigRequestBuilder.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/RewriterConfigRequestBuilder.java
@@ -150,7 +150,7 @@ public abstract class RewriterConfigRequestBuilder {
     public static class GetRewriterConfigSolrRequest extends SolrRequest<GetRewriterConfigSolrResponse> {
 
         public GetRewriterConfigSolrRequest(final String requestHandlerName, final String rewriterId) {
-            super(SolrRequest.METHOD.GET, requestHandlerName + "/" + rewriterId);
+            super(SolrRequest.METHOD.GET, requestHandlerName + (rewriterId != null ? ("/" + rewriterId) : ""));
         }
 
         @Override


### PR DESCRIPTION
And add after method to fix flanky tests.
Response format is now:
```JSON
{
  "responseHeader": {
    "status": 0,
    "QTime": 1
  },
  "response": {
    "rewriters": {
      "commonrules1": {
        "class": "querqy.solr.rewriter.commonrules.CommonRulesRewriterFactory",
        "config": {
          "rules": "notebook =>\nSYNONYM: laptop"
        }
      }
    }
  }
}
```
The format is also prepared to add meta data into the reponse element.