### PR TITLE
Handover allowBooleanInput in ClassicConf parser (issue #117)

### DIFF
--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/rewriter/commonrules/CommonRulesRewriterFactory.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/rewriter/commonrules/CommonRulesRewriterFactory.java
@@ -164,6 +164,7 @@ public class CommonRulesRewriterFactory extends SolrRewriterFactoryAdapter imple
         ifNotNull(configuration.get(CONF_IGNORE_CASE), v -> conf.put(CONF_IGNORE_CASE, v));
         ifNotNull(configuration.get(CONF_RHS_QUERY_PARSER), v -> conf.put(CONF_RHS_QUERY_PARSER, v));
         ifNotNull(configuration.get(CONF_RULE_SELECTION_STRATEGIES), v -> conf.put(CONF_RULE_SELECTION_STRATEGIES, v));
+        ifNotNull(configuration.get(CONF_ALLOW_BOOLEAN_INPUT), v -> conf.put(CONF_ALLOW_BOOLEAN_INPUT, v));
         ifNotNull(configuration.get(CONF_CLASS), v -> result.put(CONF_CLASS, v));
         return result;
     }

--- a/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/rewriter/commonrules/CommonRulesRewriterFactoryTest.java
+++ b/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/rewriter/commonrules/CommonRulesRewriterFactoryTest.java
@@ -39,6 +39,7 @@ public class CommonRulesRewriterFactoryTest {
         NamedList<Object> configuration = new NamedList<>();
         configuration.add(CONF_CLASS, CommonRulesRewriterFactory.class.getName());
         configuration.add(CONF_IGNORE_CASE, true);
+        configuration.add(CONF_ALLOW_BOOLEAN_INPUT, false);
         configuration.add(CONF_RHS_QUERY_PARSER, WhiteSpaceQuerqyParserFactory.class.getName());
         Map<String, Object> strategy = new HashMap<>();
         strategy.put("class", ExpressionSelectionStrategyFactory.class.getName());
@@ -49,11 +50,14 @@ public class CommonRulesRewriterFactoryTest {
 
         Map<String, Object> parsed = factory.parseConfigurationToRequestHandlerBody(configuration, resourceLoader);
         // no exceptions!
-        factory.configure((Map<String, Object>) parsed.get(CONF_CONFIG));
+        Map<String, Object> config = (Map<String, Object>) parsed.get(CONF_CONFIG);
+        factory.configure(config);
 
         RewriterFactory rewriterFactory = factory.getRewriterFactory();
 
         assertThat(rewriterFactory).isInstanceOf(querqy.rewrite.commonrules.SimpleCommonRulesRewriterFactory.class);
-        assertThat(factory.validateConfiguration((Map<String, Object>) parsed.get(CONF_CONFIG))).isNull();
+        assertThat(factory.validateConfiguration(config)).isNull();
+
+        assertThat(config.get(CONF_ALLOW_BOOLEAN_INPUT)).isEqualTo(false);
     }
 }


### PR DESCRIPTION
Now you can deactivate the boolean input also with the deprecated configuration parser.