### PR TITLE
Typo in parameter name!

### DIFF
--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyQParserPlugin.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyQParserPlugin.java
@@ -43,6 +43,7 @@ public abstract class QuerqyQParserPlugin extends QParserPlugin implements Resou
     public static final String CONF_CACHE_UPDATE = "termQueryCache.update";
     public static final String CONF_REWRITER_REQUEST_HANDLER = "rewriterRequestHandler";
     public static final String CONF_SKIP_UNKNOWN_REWRITERS = "skipUnknownRewriters";
+    public static final String CONF_SKIP_UNKNOWN_REWRITERS_WITH_TYPO = "skipUnkownRewriters";
 
 
     protected Logger logger = LoggerFactory.getLogger(getClass());
@@ -77,7 +78,13 @@ public abstract class QuerqyQParserPlugin extends QParserPlugin implements Resou
         }
 
         rewriterRequestHandlerName = name != null ? name : QuerqyRewriterRequestHandler.DEFAULT_HANDLER_NAME;
-        final Boolean skip = args.getBooleanArg(CONF_SKIP_UNKNOWN_REWRITERS);
+        Boolean skip = args.getBooleanArg(CONF_SKIP_UNKNOWN_REWRITERS);
+        if (skip == null) {
+          skip = args.getBooleanArg(CONF_SKIP_UNKNOWN_REWRITERS_WITH_TYPO);
+          if (skip != null){
+            logger.warn("Querqy 5.0 shipped with a typo in the parameter 'skipUnkownRewriters', please update your parameter to 'skipUnknownRewriters'.");
+          }
+        }
         skipUnknownRewriter = skip != null ? skip : false;
 
         logger.info("Initialized Querqy query parser: QuerqyRewriterRequestHandler={},skipUnknownRewriter={}",

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyQParserPlugin.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyQParserPlugin.java
@@ -42,7 +42,7 @@ public abstract class QuerqyQParserPlugin extends QParserPlugin implements Resou
     public static final String CONF_CACHE_NAME = "termQueryCache.name";
     public static final String CONF_CACHE_UPDATE = "termQueryCache.update";
     public static final String CONF_REWRITER_REQUEST_HANDLER = "rewriterRequestHandler";
-    public static final String CONF_SKIP_UNKNOWN_REWRITERS = "skipUnkownRewriters";
+    public static final String CONF_SKIP_UNKNOWN_REWRITERS = "skipUnknownRewriters";
 
 
     protected Logger logger = LoggerFactory.getLogger(getClass());

--- a/querqy-for-lucene/querqy-solr/src/test/resources/solr/collection1/conf/solrconfig-skip-unknown-rewriter.xml
+++ b/querqy-for-lucene/querqy-solr/src/test/resources/solr/collection1/conf/solrconfig-skip-unknown-rewriter.xml
@@ -8,7 +8,7 @@
 	<dataDir>${solr.core0.data.dir:}</dataDir>
 
 	<schemaFactory class="ClassicIndexSchemaFactory" />
-	
+
     <indexConfig>
         <!-- Needed for RAMDirectoryFactory -->
         <lockType>single</lockType>
@@ -53,17 +53,16 @@
 
 	<queryParser name="querqy-default" class="querqy.solr.QuerqyDismaxQParserPlugin"/>
 	<queryParser name="querqy-skip" class="querqy.solr.QuerqyDismaxQParserPlugin">
-		<bool name="skipUnkownRewriters">true</bool>
+		<bool name="skipUnknownRewriters">true</bool>
 	</queryParser>
 	<queryParser name="querqy-dont-skip" class="querqy.solr.QuerqyDismaxQParserPlugin">
-		<bool name="skipUnkownRewriters">false</bool>
+		<bool name="skipUnknownRewriters">false</bool>
 	</queryParser>
-	
 
-	
+
+
 	<admin>
 		<defaultQuery>solr</defaultQuery>
 	</admin>
 
 </config>
-


### PR DESCRIPTION
I was reading the docs and spotted the typo `skipUnkownRewriters`!  Fixed the docs, and then wondered.....     And yep, it's in the main code!

This PR fixes the typo, but doesn't provide any backwards compatibility for people using `skipUnkownRewriters` instead of `skipUnknownRewriters`.    

Should we have a warning?  I hate adding more "deprecation/warning" type code ;-)