### PR TITLE
Add close hook to rewriter container

### DIFF
--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyRewriterRequestHandler.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyRewriterRequestHandler.java
@@ -140,7 +140,7 @@ public class QuerqyRewriterRequestHandler implements SolrRequestHandler, NestedR
 
     public static final String DEFAULT_HANDLER_NAME = "/querqy/rewriter";
 
-    private RewriterContainer<?> rewriterContainer = null;
+    protected RewriterContainer<?> rewriterContainer = null;
 
     @SuppressWarnings({"rawtypes"})
     private NamedList initArgs = null;

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/RewriterContainer.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/RewriterContainer.java
@@ -2,6 +2,7 @@ package querqy.solr;
 
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.util.NamedList;
+import org.apache.solr.core.CloseHook;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.core.SolrResourceLoader;
 import org.apache.solr.search.SolrIndexSearcher;
@@ -34,12 +35,22 @@ public abstract class RewriterContainer<R extends SolrResourceLoader> {
     }
 
     protected RewriterContainer(final SolrCore core, final R resourceLoader) {
-
         if (core.getResourceLoader() != resourceLoader) {
             throw new IllegalArgumentException("ResourceLoader doesn't belong to this SolrCore");
         }
         this.core = core;
         this.resourceLoader = resourceLoader;
+        this.core.addCloseHook(new CloseHook(){
+            @Override
+            public void postClose(SolrCore core) {
+                // noop
+            }
+
+            @Override
+            public void preClose(SolrCore core) {
+                close();                
+            }
+        });
     }
 
     protected abstract void init(@SuppressWarnings({"rawtypes"}) NamedList args);

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/ZkRewriterContainer.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/ZkRewriterContainer.java
@@ -211,9 +211,12 @@ public class ZkRewriterContainer extends RewriterContainer<ZkSolrResourceLoader>
         final List<String> children;
         try {
             children = zkClient.getChildren(inventoryPath, event -> {
-                // register a Watcher on the directory
-                onDirectoryChanged();
-                notifyRewritersChangeListener();
+                // register a Watcher on the directory 
+                // if we're not closed yet
+                if (zkClient != null) {
+                    onDirectoryChanged();
+                    notifyRewritersChangeListener();
+                }
             }, true).stream() // get all children except for the .data subdirectory
                     .filter(child -> !IO_DATA.equals(child))
                     .collect(Collectors.toList());

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/ZkRewriterContainer.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/ZkRewriterContainer.java
@@ -37,6 +37,7 @@ public class ZkRewriterContainer extends RewriterContainer<ZkSolrResourceLoader>
 
     public static final int DEFAULT_MAX_FILE_SIZE = 1000000;
     public static final String CONF_MAX_FILE_SIZE = "zkMaxFileSize";
+    public static final String CONF_CONFIG_NAME = "zkConfigName";
 
     protected static final String IO_PATH = "querqy/rewriters";
     protected static final String IO_DATA = ".data";
@@ -65,7 +66,10 @@ public class ZkRewriterContainer extends RewriterContainer<ZkSolrResourceLoader>
 
         final String zkConfigName;
         try {
-            zkConfigName = zkController.getZkStateReader().readConfigName(collection);
+            zkConfigName = NamedListWrapper
+                .create(args, "Error in ZkRewriterContainer config")
+                .getStringOrDefault(CONF_CONFIG_NAME, 
+                    zkController.getZkStateReader().readConfigName(collection));
         } catch (final Exception e) {
             throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Failed to load config name for collection:" +
                     collection  + " due to: ", e);

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/utils/NamedListWrapper.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/utils/NamedListWrapper.java
@@ -62,6 +62,17 @@ public class NamedListWrapper {
 
         return objAsString.trim();
     }
+    
+    public String getStringOrDefault(String key, String defaultValue) {
+        final Object obj = namedList.get(key);
+        if (obj == null) {
+            return defaultValue;
+        } else if (obj instanceof String) {
+            return ((String) obj).trim();
+        } else {
+            throw new IllegalArgumentException(this.exceptionMessage);
+        }
+    }
 
     public int getOrDefaultInteger(String key, int defaultValue) {
         try {


### PR DESCRIPTION
This PR fixes #177 which can cause a severe memory leak (at least in our environment).

The `RewriterContainer` has a `close()` method but unfortunately this has not been called anywhere. With this PR all implementations of `RewriterContainer` receive a `close()` call upon `SolrCore#close()`