### PR TITLE
Fix memory leak (adds close hook to RewriterContainer)

### DIFF
--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/RewriterContainer.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/RewriterContainer.java
@@ -41,15 +41,29 @@ public abstract class RewriterContainer<R extends SolrResourceLoader> {
         this.core = core;
         this.resourceLoader = resourceLoader;
         this.core.addCloseHook(new CloseHook(){
+
+            /**
+             * (1) Is called before any component is closed. To guarantee consistency,
+             * we keep the container alive as long as the QuerqyRewriterRequestHandler
+             * is not closed
+             */
             @Override
-            public void postClose(SolrCore core) {
+            public void preClose(SolrCore core) {
                 // noop
             }
 
+            /**
+             * (2) the QuerqyRewriterRequestHandler is closed
+             * 
+             * (3) the SolrCore is closed
+             * 
+             * (4) We are going to close the RewriterContainer
+             */
             @Override
-            public void preClose(SolrCore core) {
-                close();                
+            public void postClose(SolrCore core) {
+                close();
             }
+            
         });
     }
 

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/RewriterContainer.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/RewriterContainer.java
@@ -2,6 +2,7 @@ package querqy.solr;
 
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.util.NamedList;
+import org.apache.solr.core.CloseHook;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.core.SolrResourceLoader;
 import org.apache.solr.search.SolrIndexSearcher;
@@ -34,12 +35,22 @@ public abstract class RewriterContainer<R extends SolrResourceLoader> {
     }
 
     protected RewriterContainer(final SolrCore core, final R resourceLoader) {
-
         if (core.getResourceLoader() != resourceLoader) {
             throw new IllegalArgumentException("ResourceLoader doesn't belong to this SolrCore");
         }
         this.core = core;
         this.resourceLoader = resourceLoader;
+        this.core.addCloseHook(new CloseHook(){
+            @Override
+            public void postClose(SolrCore core) {
+                // noop
+            }
+
+            @Override
+            public void preClose(SolrCore core) {
+                close();                
+            }
+        });
     }
 
     protected abstract void init(@SuppressWarnings({"rawtypes"}) NamedList args);

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/ZkRewriterContainer.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/ZkRewriterContainer.java
@@ -207,9 +207,12 @@ public class ZkRewriterContainer extends RewriterContainer<ZkSolrResourceLoader>
         final List<String> children;
         try {
             children = zkClient.getChildren(inventoryPath, event -> {
-                // register a Watcher on the directory
-                onDirectoryChanged();
-                notifyRewritersChangeListener();
+                // register a Watcher on the directory 
+                // if we're not closed yet
+                if (zkClient != null) {
+                    onDirectoryChanged();
+                    notifyRewritersChangeListener();
+                }
             }, true).stream() // get all children except for the .data subdirectory
                     .filter(child -> !IO_DATA.equals(child))
                     .collect(Collectors.toList());


### PR DESCRIPTION
This PR fixes the possible memory leak described in #177 by properly closing the `RewriterContainer`.