### PR TITLE
Allowing escaping of `*`, `"`, `#` and `\` for rule input

### DIFF
--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/EscapeUtil.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/EscapeUtil.java
@@ -1,0 +1,78 @@
+package querqy.rewrite.commonrules;
+
+import static querqy.rewrite.commonrules.LineParser.BOUNDARY;
+import static querqy.rewrite.commonrules.LineParser.WILDCARD;
+import static querqy.rewrite.commonrules.SimpleCommonRulesParser.COMMENT_START;
+
+public class EscapeUtil {
+
+    static final char ESCAPE = '\\';
+
+    public static int indexOfComment(String s) {
+        return indexIfNotEscaped(s, COMMENT_START);
+    }
+
+    public static int indexOfWildcard(String s) {
+        return indexIfNotEscaped(s, WILDCARD);
+    }
+
+    public static boolean endsWithWildcard(String s) {
+        return endsWithSpecialChar(s, WILDCARD);
+    }
+
+    public static boolean endsWithBoundary(String s) {
+        return endsWithSpecialChar(s, BOUNDARY);
+    }
+
+    // Checks whether String ends with a character that has special meaning, considering an escape sequence
+    public static boolean endsWithSpecialChar(String s, char ch) {
+        return (s.length() > 0 && s.charAt(s.length() - 1) == ch && !(s.length() > 1 && s.charAt(s.length() -2) == ESCAPE));
+    }
+
+    public static int indexIfNotEscaped(String s, char lookupChar) {
+        boolean inEscape = false;
+        for (int i = 0; i < s.length(); i++) {
+            char ch = s.charAt(i);
+            if (ch == lookupChar && !inEscape) {
+                return i;
+            } else {
+                inEscape = ch == ESCAPE && !inEscape;
+            }
+        }
+        return -1;
+    }
+
+    public static String unescape(String s) {
+        if (s.indexOf(ESCAPE) == -1) {
+            return s;
+        } else {
+            final char[] buf = new char[s.length()];
+            boolean inEscape = false;
+            int j = 0;
+            for (int i = 0; i < s.length(); i++) {
+                char ch = s.charAt(i);
+                if (inEscape) {
+                    switch (ch) {
+                        case ESCAPE:
+                        case WILDCARD:
+                        case COMMENT_START:
+                        case BOUNDARY:
+                            buf[j++] = ch;
+                            break;
+                        default:
+                            throw new IllegalArgumentException("Illegal escape sequence \\" + ch);
+                    }
+                    inEscape = false;
+                } else {
+                    if (ch == ESCAPE) {
+                        inEscape = true;
+                    } else {
+                        buf[j++] = ch;
+                    }
+                }
+            }
+            return new String(buf, 0, j);
+        }
+    }
+
+}

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/EscapeUtil.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/EscapeUtil.java
@@ -8,41 +8,24 @@ public class EscapeUtil {
 
     static final char ESCAPE = '\\';
 
-    public static int indexOfComment(String s) {
+    public static int indexOfComment(final String s) {
         return indexIfNotEscaped(s, COMMENT_START);
     }
 
-    public static int indexOfWildcard(String s) {
+    public static int indexOfWildcard(final String s) {
         return indexIfNotEscaped(s, WILDCARD);
     }
 
-    public static boolean endsWithWildcard(String s) {
+    public static boolean endsWithWildcard(final String s) {
         return endsWithSpecialChar(s, WILDCARD);
     }
 
-    public static boolean endsWithBoundary(String s) {
+    public static boolean endsWithBoundary(final String s) {
         return endsWithSpecialChar(s, BOUNDARY);
     }
 
-    // Checks whether String ends with a character that has special meaning, considering an escape sequence
-    public static boolean endsWithSpecialChar(String s, char ch) {
-        return (s.length() > 0 && s.charAt(s.length() - 1) == ch && !(s.length() > 1 && s.charAt(s.length() -2) == ESCAPE));
-    }
-
-    public static int indexIfNotEscaped(String s, char lookupChar) {
-        boolean inEscape = false;
-        for (int i = 0; i < s.length(); i++) {
-            char ch = s.charAt(i);
-            if (ch == lookupChar && !inEscape) {
-                return i;
-            } else {
-                inEscape = ch == ESCAPE && !inEscape;
-            }
-        }
-        return -1;
-    }
-
-    public static String unescape(String s) {
+    // Returns the string with any of the supported escape sequences (\" \* \# and \\) un-escaped
+    public static String unescape(final String s) {
         if (s.indexOf(ESCAPE) == -1) {
             return s;
         } else {
@@ -75,4 +58,22 @@ public class EscapeUtil {
         }
     }
 
+    // Checks whether String ends with a character that has special meaning, considering an escape sequence
+    private static boolean endsWithSpecialChar(final String s, final char ch) {
+        return (s.length() > 0 && s.charAt(s.length() - 1) == ch && !(s.length() > 1 && s.charAt(s.length() -2) == ESCAPE));
+    }
+
+    // Returns the first position of lookupChar in s not considering occurences where lookupChar was escaped using '\'
+    private static int indexIfNotEscaped(final String s, final char lookupChar) {
+        boolean inEscape = false;
+        for (int i = 0; i < s.length(); i++) {
+            char ch = s.charAt(i);
+            if (ch == lookupChar && !inEscape) {
+                return i;
+            } else {
+                inEscape = ch == ESCAPE && !inEscape;
+            }
+        }
+        return -1;
+    }
 }

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/LineParser.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/LineParser.java
@@ -1,5 +1,10 @@
 package querqy.rewrite.commonrules;
 
+import static querqy.rewrite.commonrules.EscapeUtil.endsWithBoundary;
+import static querqy.rewrite.commonrules.EscapeUtil.endsWithWildcard;
+import static querqy.rewrite.commonrules.EscapeUtil.indexOfWildcard;
+import static querqy.rewrite.commonrules.EscapeUtil.unescape;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -364,12 +369,12 @@ public class LineParser {
             s = s.substring(1).trim();
         }
 
-        if (s.length() > 0 && s.charAt(s.length() - 1) == BOUNDARY) {
+        if (endsWithBoundary(s)) {
             requiresRightBoundary = true;
             s = s.substring(0, s.length() - 1).trim();
         }
 
-        int pos = s.indexOf('*');
+        int pos = indexOfWildcard(s);
         if (pos > -1) {
             if (pos < (s.length() - 1)) {
                 return new ValidationError(WILDCARD + " is only allowed at the end of the input: " + s);
@@ -437,9 +442,11 @@ public class LineParser {
             throw new IllegalArgumentException("Missing prefix for wildcard " + WILDCARD);
         }
 
-        return (remaining.charAt(remaining.length() - 1) == WILDCARD)
-                ? new PrefixTerm(remaining.toCharArray(), 0, remaining.length() - 1, fieldNames)
-                : new Term(remaining.toCharArray(), 0, remaining.length(), fieldNames);
+        String remainingUnescaped = unescape(remaining);
+
+        return endsWithWildcard(remaining)
+                ? new PrefixTerm(remainingUnescaped.toCharArray(), 0, remainingUnescaped.length() - 1, fieldNames)
+                : new Term(remainingUnescaped.toCharArray(), 0, remainingUnescaped.length(), fieldNames);
 
 
     }

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/LineParser.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/LineParser.java
@@ -442,7 +442,7 @@ public class LineParser {
             throw new IllegalArgumentException("Missing prefix for wildcard " + WILDCARD);
         }
 
-        String remainingUnescaped = unescape(remaining);
+        final String remainingUnescaped = unescape(remaining);
 
         return endsWithWildcard(remaining)
                 ? new PrefixTerm(remainingUnescaped.toCharArray(), 0, remainingUnescaped.length() - 1, fieldNames)

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/SimpleCommonRulesParser.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/SimpleCommonRulesParser.java
@@ -9,6 +9,7 @@ import querqy.rewrite.commonrules.model.TrieMapRulesCollectionBuilder;
 import querqy.rewrite.commonrules.select.booleaninput.model.BooleanInputLiteral;
 import querqy.rewrite.commonrules.select.booleaninput.BooleanInputParser;
 
+import static querqy.rewrite.commonrules.EscapeUtil.indexOfComment;
 import static querqy.rewrite.commonrules.model.Instructions.StandardPropertyNames.ID;
 import static querqy.rewrite.commonrules.model.Instructions.StandardPropertyNames.LOG_MESSAGE;
 
@@ -30,6 +31,8 @@ import java.util.function.IntUnaryOperator;
  * @author rene
  */
 public class SimpleCommonRulesParser {
+
+    static final char COMMENT_START = '#';
 
     private static final String EMPTY = "";
 
@@ -184,7 +187,7 @@ public class SimpleCommonRulesParser {
     String stripLine(String line) {
         line = line.trim();
         if (line.length() > 0) {
-            int pos = line.indexOf('#');
+            int pos = indexOfComment(line);
             if (pos == 0) {
                 return EMPTY;
             }
@@ -194,5 +197,4 @@ public class SimpleCommonRulesParser {
         }
         return line;
     }
-    
 }

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/select/booleaninput/BooleanInputParser.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/select/booleaninput/BooleanInputParser.java
@@ -65,7 +65,11 @@ public class BooleanInputParser {
     protected String unescapeElement(final String element) {
         return this.mappingToUnescapeElements.getOrDefault(element, element)
                 .replace("\\(", "(")
-                .replace("\\)", ")");
+                .replace("\\)", ")")
+                .replace("\\*", "*")
+                .replace("\\\"", "\"")
+                .replace("\\#", "#")
+                .replace("\\\\", "\\");
     }
 
     protected Stream<String> separateParenthesesFromElements(final String element) {

--- a/querqy-core/src/test/java/querqy/rewrite/commonrules/EscapeUtilTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/commonrules/EscapeUtilTest.java
@@ -1,0 +1,24 @@
+package querqy.rewrite.commonrules;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static querqy.rewrite.commonrules.EscapeUtil.unescape;
+
+import org.junit.Test;
+
+public class EscapeUtilTest {
+
+    @Test
+    public void testUnescape() {
+        assertThat(unescape("\\*")).isEqualTo("*");
+        assertThat(unescape("\\\"")).isEqualTo("\"");
+        assertThat(unescape("\\#")).isEqualTo("#");
+        assertThat(unescape("\\\\")).isEqualTo("\\");
+        assertThat(unescape("\\\\*")).isEqualTo("\\*");
+        assertThatThrownBy(() -> unescape("\\1")).isExactlyInstanceOf(IllegalArgumentException.class);
+        assertThat(unescape("a\\\\")).isEqualTo("a\\");
+        assertThat(unescape("a\\*")).isEqualTo("a*");
+        assertThat(unescape("\\")).isEqualTo("");
+    }
+
+}

--- a/querqy-core/src/test/java/querqy/rewrite/commonrules/SimpleParserTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/commonrules/SimpleParserTest.java
@@ -1,5 +1,6 @@
 package querqy.rewrite.commonrules;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.*;
@@ -24,10 +25,10 @@ import querqy.rewrite.commonrules.model.*;
 import querqy.rewrite.commonrules.model.BoostInstruction.BoostDirection;
 
 public class SimpleParserTest extends AbstractCommonRulesTest {
-    
-    Reader reader; 
+
+    Reader reader;
     QuerqyParserFactory querqyParserFactory = new WhiteSpaceQuerqyParserFactory();
-    
+
     SimpleCommonRulesParser createParserWithEmptyReader() {
         return createParserFromString("", false);
     }
@@ -46,12 +47,12 @@ public class SimpleParserTest extends AbstractCommonRulesTest {
         SimpleCommonRulesParser parser = createParserFromResource(resourceName, ignoreCase);
         return parser.parse();
     }
-    
+
     Query makeQueryUsingFactory(String qString) {
         return querqyParserFactory.createParser().parse(qString);
     }
-    
-    
+
+
     @After
     public void tearDown() throws IOException {
         if (reader != null) {
@@ -69,7 +70,7 @@ public class SimpleParserTest extends AbstractCommonRulesTest {
         assertEquals("", parser.stripLine(" #sdsd"));
         assertEquals("", parser.stripLine("\t #sdsd"));
     }
-    
+
     @Test
     public void test01() throws Exception {
         RulesCollection rules = createRulesFromResource("rules-test.txt", false);
@@ -105,7 +106,7 @@ public class SimpleParserTest extends AbstractCommonRulesTest {
         seq.nextPosition();
         seq.addElement(t4);
         List<Action> actions = getActions(rules, seq);
-        assertThat(actions, contains( 
+        assertThat(actions, contains(
 
                 new Action(
                                 new Instructions(1, "1",
@@ -113,7 +114,7 @@ public class SimpleParserTest extends AbstractCommonRulesTest {
                                                 new DeleteInstruction(Collections.singletonList(mkTerm("b")))
                                         )),
                                                 new TermMatches(Arrays.asList(new TermMatch(t1), new TermMatch(t2))), 0, 2),
-                                
+
                 new Action(
                                 new Instructions(3, "3",
                                         Arrays.asList(
@@ -129,9 +130,9 @@ public class SimpleParserTest extends AbstractCommonRulesTest {
                                 )),
                         new TermMatches(new TermMatch(t1)), 0, 1)
 
-                ));	
+                ));
     }
-    
+
     @Test
     public void test04() throws Exception {
         RulesCollection rules = createRulesFromResource("rules-test.txt", false);
@@ -143,18 +144,18 @@ public class SimpleParserTest extends AbstractCommonRulesTest {
         seq.nextPosition();
         seq.addElement(t2);
         List<Action> actions = getActions(rules, seq);
-        assertThat(actions, contains( 
+        assertThat(actions, contains(
                 new Action(
                                 new Instructions(1, "1",
                                         Collections.singletonList(
                                                 new BoostInstruction(makeQueryUsingFactory("tboost tb2"), BoostDirection.UP, 3.5f)
                                         )),
                                                         new TermMatches(Arrays.asList(new TermMatch(t1), new TermMatch(t2))), 0, 2)
-                
-                
+
+
                 ));
     }
-    
+
     @Test
     public void test05() throws Exception {
         RulesCollection rules = createRulesFromResource("rules-test.txt", false);
@@ -170,28 +171,28 @@ public class SimpleParserTest extends AbstractCommonRulesTest {
                                 )
                         ),
                         new TermMatches(new TermMatch(t1)), 0, 1)
-                
-                
+
+
                 ));
     }
-  
-/*    
-    
+
+/*
+
 ts3 =>
     SYNONYM: syn2
-    
+
 ts4 ts5 =>
     SYNONYM: syn3  syn4
-    
+
 ts6 =>
     SYNONYM: syn5 syn6 syn7
 */
-    
+
     /**
-     *   
+     *
      *   ts1 ts2 =>
      *       SYNONYM: syn1
-     *   
+     *
      * @throws Exception
      */
     @Test
@@ -213,11 +214,11 @@ ts6 =>
                                 )
                                         ),
                         new TermMatches(Arrays.asList(new TermMatch(t1), new TermMatch(t2))), 0, 2)
-                
-                
+
+
                 ));
     }
-    
+
     /**
      * ts6 =>
      *    SYNONYM: syn5 f1:syn6 {f2,f3}:syn7
@@ -244,13 +245,13 @@ ts6 =>
                                         )
                                         ),
                                                         new TermMatches(new TermMatch(t1)), 0, 1)
-                
-                
+
+
                 ));
     }
-    
+
     /**
-     * tS7 Ts8 TS => 
+     * tS7 Ts8 TS =>
      *    FILTER : FLT4
      * @throws Exception
      */
@@ -270,11 +271,11 @@ ts6 =>
         seq.addElement(t3);
         List<Action> actions = getActions(rules, seq);
         assertTrue(actions.isEmpty());
-        
+
     }
-    
+
     /**
-     * tS7 Ts8 TS => 
+     * tS7 Ts8 TS =>
      *    FILTER : FLT4
      * @throws Exception
      */
@@ -294,20 +295,20 @@ ts6 =>
         seq.addElement(t3);
         List<Action> actions = getActions(rules, seq);
 
-        assertThat(actions, contains( 
+        assertThat(actions, contains(
                 new Action(
                         new Instructions(1, "1",
                                 Collections.singletonList(
                                                 new FilterInstruction(makeQueryUsingFactory("FLT4"))
                                         )),
                         new TermMatches(Arrays.asList(new TermMatch(t1), new TermMatch(t2), new TermMatch(t3))), 0, 3)
-                
-                
+
+
                 ));
     }
-    
+
     /**
-     * tS7 Ts8 TS => 
+     * tS7 Ts8 TS =>
      *    FILTER : FLT4
      * @throws Exception
      */
@@ -327,20 +328,20 @@ ts6 =>
         seq.addElement(t3);
         List<Action> actions = getActions(rules, seq);
 
-        assertThat(actions, contains( 
+        assertThat(actions, contains(
                 new Action(
                         new Instructions(1, "1",
                                 Collections.singletonList(
                                         new FilterInstruction(makeQueryUsingFactory("FLT4"))
                                 )),
                         new TermMatches(Arrays.asList(new TermMatch(t1), new TermMatch(t2), new TermMatch(t3))), 0, 3)
-                
-                
+
+
                 ));
     }
-    
+
     /**
-     * tS7 Ts8 TS => 
+     * tS7 Ts8 TS =>
      *    FILTER : FLT4
      * @throws Exception
      */
@@ -360,7 +361,7 @@ ts6 =>
         seq.addElement(t3);
         List<Action> actions = getActions(rules, seq);
 
-        assertThat(actions, contains( 
+        assertThat(actions, contains(
                 new Action(
                         new Instructions(1, "1",
                                 Collections.singletonList(
@@ -369,7 +370,7 @@ ts6 =>
                         new TermMatches(Arrays.asList(new TermMatch(t1), new TermMatch(t2), new TermMatch(t3))), 0, 3)
                 ));
     }
-    
+
     /**
      * "tb1 =>
      *   FILTER: FLTTB1
@@ -397,7 +398,7 @@ ts6 =>
         seq.addElement(CommonRulesRewriter.RIGHT_BOUNDARY);
         List<Action> actions = getActions(rules, seq);
 
-        assertThat(actions, contains( 
+        assertThat(actions, contains(
                 new Action(
                         new Instructions(1, "1",
                                 Collections.singletonList(
@@ -406,7 +407,7 @@ ts6 =>
                         new TermMatches(Collections.singletonList(new TermMatch(t1))), 0, 1)
                 ));
     }
-    
+
     /**
      * "tb1 =>
      *   FILTER: FLTTB1
@@ -434,15 +435,15 @@ ts6 =>
         seq.addElement(CommonRulesRewriter.RIGHT_BOUNDARY);
         List<Action> actions = getActions(rules, seq);
 
-        assertThat(actions, not(contains( 
+        assertThat(actions, not(contains(
                 new Action(
                         new Instructions(1, "1",
                                 Collections.singletonList(new FilterInstruction(makeQueryUsingFactory("FLTTB1")
                                 ))),
                                 new TermMatches(Collections.singletonList(new TermMatch(t1))), 0, 1)
                 )));
-    }   
-    
+    }
+
     /**
      * "tb1 =>
      *   FILTER: FLTTB1
@@ -467,7 +468,7 @@ ts6 =>
         seq.addElement(CommonRulesRewriter.RIGHT_BOUNDARY);
         List<Action> actions = getActions(rules, seq);
 
-        assertThat(actions, contains( 
+        assertThat(actions, contains(
                 new Action(
                         new Instructions(1, "1",
                                 Collections.singletonList(
@@ -504,7 +505,7 @@ ts6 =>
         seq.addElement(CommonRulesRewriter.RIGHT_BOUNDARY);
         List<Action> actions = getActions(rules, seq);
 
-        assertThat(actions, not(contains( 
+        assertThat(actions, not(contains(
                 new Action(
                         new Instructions(1, "1",
                                 Collections.singletonList(new FilterInstruction(makeQueryUsingFactory("FLTTB2")
@@ -512,12 +513,12 @@ ts6 =>
                          new TermMatches(Collections.singletonList(new TermMatch(t2))), 0, 1)
 
                 )));
-    }  
-    
+    }
+
     /**
      * "tb4*" =>
      *      FILTER: FLTTB4
-     *      
+     *
      * @throws Exception
      */
     //@Test TODO enable test once we can handle wild card before right input boundary
@@ -533,7 +534,7 @@ ts6 =>
         seq.addElement(CommonRulesRewriter.RIGHT_BOUNDARY);
         List<Action> actions = getActions(rules, seq);
 
-        assertThat(actions, contains( 
+        assertThat(actions, contains(
                 new Action(
                         new Instructions(1, "1",
                                 Collections.singletonList(new FilterInstruction(makeQueryUsingFactory("FLTTB4")
@@ -542,7 +543,87 @@ ts6 =>
                 ));
     }
 
-    
+/*
+# 18 Rule with escaped comment
+"\#9" =>
+    FILTER: num9
+*/
+    @Test
+    public void test18() throws Exception {
+        RulesCollection rules = createRulesFromResource("rules-test.txt", true);
+        Term term = new Term(null, "#9");
+        PositionSequence<InputSequenceElement> seq = new PositionSequence<>();
+        seq.nextPosition();
+        seq.addElement(CommonRulesRewriter.LEFT_BOUNDARY);
+        seq.nextPosition();
+        seq.addElement(term);
+        seq.nextPosition();
+        seq.addElement(CommonRulesRewriter.RIGHT_BOUNDARY);
+        List<Action> actions = getActions(rules, seq);
+
+        assertThat(actions, contains(
+                new Action(
+                        new Instructions(1, "1",
+                                Collections.singletonList(new FilterInstruction(makeQueryUsingFactory("num9")
+                                ))),
+                        new TermMatches(Collections.singletonList(new TermMatch(term))), 0, 1)
+        ));
+    }
+
+/*
+# 19: Rule escaped wildcard
+4\*4 =>
+    SYNONYM: 4x4
+ */
+    @Test
+    public void test19() throws Exception {
+        RulesCollection rules = createRulesFromResource("rules-test.txt", true);
+        Term term = new Term(null, "4*4");
+        PositionSequence<InputSequenceElement> seq = new PositionSequence<>();
+        seq.nextPosition();
+        seq.addElement(CommonRulesRewriter.LEFT_BOUNDARY);
+        seq.nextPosition();
+        seq.addElement(term);
+        seq.nextPosition();
+        seq.addElement(CommonRulesRewriter.RIGHT_BOUNDARY);
+        List<Action> actions = getActions(rules, seq);
+
+        assertThat(actions, contains(
+                new Action(
+                        new Instructions(1, "1",
+                                Collections.singletonList(new SynonymInstruction(singletonList(mkTerm("4x4"))
+                                ))),
+                        new TermMatches(Collections.singletonList(new TermMatch(term))), 0, 1)
+        ));
+    }
+
+/*
+# 20: Rule escaped boundary
+"bicycle 27\"" =>
+    FILTER: size27
+ */
+    @Test
+    public void test20() throws Exception {
+        RulesCollection rules = createRulesFromResource("rules-test.txt", true);
+        Term term = new Term(null, "bicycle 27\"");
+        PositionSequence<InputSequenceElement> seq = new PositionSequence<>();
+        seq.nextPosition();
+        seq.addElement(CommonRulesRewriter.LEFT_BOUNDARY);
+        seq.nextPosition();
+        seq.addElement(term);
+        seq.nextPosition();
+        seq.addElement(CommonRulesRewriter.RIGHT_BOUNDARY);
+        List<Action> actions = getActions(rules, seq);
+
+        assertThat(actions, contains(
+                new Action(
+                        new Instructions(1, "1",
+                                Collections.singletonList(new FilterInstruction(makeQueryUsingFactory("size27")
+                                ))),
+                        new TermMatches(Collections.singletonList(new TermMatch(term))), 0, 1)
+        ));
+    }
+
     @Test
     public void testError01() throws Exception {
         try {

--- a/querqy-core/src/test/java/querqy/rewrite/commonrules/select/booleaninput/BooleanInputParserTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/commonrules/select/booleaninput/BooleanInputParserTest.java
@@ -97,12 +97,32 @@ public class BooleanInputParserTest {
                 .isEqualTo(list(term("a"), and(), term("(b)")));
     }
 
+    @Test
+    public void handlesVerbatimWildcardQuoteAndHashAsLiterals() {
+        BooleanInputParser parser = new BooleanInputParser();
+
+        assertThat(parser.parseInputStringToElements("12\" AND 1*1 OR #9"))
+                .isEqualTo(list(term("12\""), and(), term("1*1"), or(), term("#9")));
+    }
+
+    @Test
+    public void unescapesWildcardQuoteAndHashAsLiterals() {
+        BooleanInputParser parser = new BooleanInputParser();
+
+        assertThat(parser.parseInputStringToElements("12\\\" AND 1\\*1 OR \\#9"))
+                .isEqualTo(list(term("12\""), and(), term("1*1"), or(), term("#9")));
+    }
+
     private BooleanInputElement term(String term) {
         return new BooleanInputElement(term, BooleanInputElement.Type.TERM);
     }
 
     private BooleanInputElement and() {
         return new BooleanInputElement("AND", BooleanInputElement.Type.AND);
+    }
+
+    private BooleanInputElement or() {
+        return new BooleanInputElement("OR", BooleanInputElement.Type.OR);
     }
 
     private BooleanInputElement leftP() {

--- a/querqy-core/src/test/resources/rules-test.txt
+++ b/querqy-core/src/test/resources/rules-test.txt
@@ -1,61 +1,71 @@
 # test 01: delete single token a
 aa =>
 	DELETE
-	
+
 # test 02:  delete b queried after a
 a b =>
 	DELETE: b
-		
+
 {y,z}:a b =>
 	DELETE: z:a
-	
+
 a b c =>
 	DELETE: a
 	DELETE: c
-	
-# end of test 02	
-	
-	
+
+# end of test 02
+
+
 # test 03: delete a queried before b in fields y and z
 #{y,z}:(a b) =>
 #	DELETE: {y,z}:a
-	
+
 
 pf xp =>
 	FILTER: * price:[* TO 100]
-	
+
 tf2 =>
 	FILTER: flt2 flt3
-	
+
 a =>
 	DOWN(2): * color:x
-	
+
 t1 t2 =>
 	UP(3.5): tboost tb2
-	
-	
+
+
 ts1 ts2 =>
 	SYNONYM: syn1
-	
+
 ts6 =>
 	SYNONYM: syn5 f1:syn6 {f2,f3}:syn7
 
-# test ignore case	
-tS7 Ts8 TS => 
+# test ignore case
+tS7 Ts8 TS =>
 	FILTER : FLT4
-	
+
 
 "tb1 =>
 	FILTER: FLTTB1
-	 
+
 "tb2" =>
 	FILTER: FLTTB2
-	
+
 tb3" =>
 	FILTER: FLTTB3
-	
+
 # Enable once we can deal with the wildcard followed by the input boundary
 #"tb4*" =>
 #	FILTER: FLTTB4
 
-	
+# 18 Rule with escaped comment
+"\#9" =>
+    FILTER: num9
+
+# 19: Rule escaped wildcard
+4\*4 =>
+    SYNONYM: 4x4
+
+# 20: Rule escaped boundary
+"bicycle 27\"" =>
+    FILTER: size27


### PR DESCRIPTION
A first shot at allowing escaping of some characters in rules input for common rules rewriter.
