### PR TITLE
Add dismax when calculating scores of synonym expansions #281

### DIFF
--- a/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/LuceneSearchEngineRequestAdapter.java
+++ b/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/LuceneSearchEngineRequestAdapter.java
@@ -168,7 +168,7 @@ public interface LuceneSearchEngineRequestAdapter extends SearchEngineRequestAda
      * </p>
      * <p>If an empty Optional is returned, {@link QueryParsingController#DEFAULT_MULTI_MATCH_TIEBREAKER} will be used.</p>
      *
-     * @return An optional tiebreaker.
+     * @return An optional multi-match tiebreaker.
      */
     Optional<Float> getMultiMatchTiebreaker();
 

--- a/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/LuceneSearchEngineRequestAdapter.java
+++ b/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/LuceneSearchEngineRequestAdapter.java
@@ -155,6 +155,24 @@ public interface LuceneSearchEngineRequestAdapter extends SearchEngineRequestAda
     Optional<Float> getTiebreaker();
 
     /**
+     * <p>Get an optional tiebreaker for multiple matches in a single field.</p>
+     * <p>This tie parameter is applied to the scores of terms that are expansions of input terms when they are
+     * mapped to fields. For example, given an input query 'asus laptop' and a synonym expansion 'notebook' for laptop,
+     * and the two query fields f1 and f2, the multiMatchTiebreaker and the tiebreaker would be applied as follows:
+     * <pre>
+     *     (f1:asus | f2:asus)~tiebreaker ((f1:laptop|f1:notebook)~multiMatchTieBreaker (f2:laptop|f2:notebook)~multiMatchTieBreaker)~tiebreaker
+     * </pre>
+     * <p>A multiMatchTiebreaker of 1.0 would sum up the scores of the laptop/notebook synonym matches and thus prefer
+     * those documents that contain all synonyms, whereas a value of 0.0 would only use the maximum score of the two
+     * synonyms.
+     * </p>
+     * <p>If an empty Optional is returned, {@link QueryParsingController#DEFAULT_MULTI_MATCH_TIEBREAKER} will be used.</p>
+     *
+     * @return An optional tiebreaker.
+     */
+    Optional<Float> getMultiMatchTiebreaker();
+
+    /**
      * <p>Apply the 'minimum should match' setting of the request.</p>
      * <p>It will be the responsibility of the LuceneSearchEngineRequestAdapter implementation to derive the
      * 'minimum should match' setting from request parameters or other configuration.</p>

--- a/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/QueryParsingController.java
+++ b/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/QueryParsingController.java
@@ -56,6 +56,7 @@ public class QueryParsingController {
     protected static final QuerySimilarityScoring DEFAULT_BOOST_QUERY_SIMILARITY_SCORING = QuerySimilarityScoring.DFC;
 
     protected static final float DEFAULT_TIEBREAKER = 0f;
+    protected static final float DEFAULT_MULTI_MATCH_TIEBREAKER = 1f;
 
     protected static final float DEFAULT_POSITIVE_QUERQY_BOOST_WEIGHT = 1f;
     protected static final float DEFAULT_NEGATIVE_QUERQY_BOOST_WEIGHT = 1f;
@@ -115,7 +116,7 @@ public class QueryParsingController {
         searchFieldsAndBoosting = new SearchFieldsAndBoosting(
                 needsScores
                         ? requestAdapter.getFieldBoostModel().orElse(DEFAULT_FIELD_BOOST_MODEL)
-                        : FieldBoostModel.FIXED,
+                        : FieldBoostModel.FIXED, // TODO: better use NONE as FBM?
                 queryFieldsAndBoostings,
                 generatedQueryFieldsAndBoostings,
                 gfb);
@@ -126,7 +127,7 @@ public class QueryParsingController {
             boostTermQueryBuilder = null;
             boostSearchFieldsAndBoostings = null;
             builder = new LuceneQueryBuilder(new LuceneTermQueryBuilder(), queryAnalyzer, searchFieldsAndBoosting, 1f,
-                    requestAdapter.getTermQueryCache().orElse(null));
+                    1f, requestAdapter.getTermQueryCache().orElse(null));
         } else {
             addQuerqyBoostQueriesToMainQuery = requestAdapter.addQuerqyBoostQueriesToMainQuery();
 
@@ -149,6 +150,7 @@ public class QueryParsingController {
 
             builder = new LuceneQueryBuilder(userTermQueryBuilder,
                     queryAnalyzer, searchFieldsAndBoosting, requestAdapter.getTiebreaker().orElse(DEFAULT_TIEBREAKER),
+                    requestAdapter.getMultiMatchTiebreaker().orElse(DEFAULT_MULTI_MATCH_TIEBREAKER),
                     requestAdapter.getTermQueryCache().orElse(null));
 
         }
@@ -374,6 +376,7 @@ public class QueryParsingController {
                             new LuceneQueryBuilder(boostTermQueryBuilder, queryAnalyzer,
                                     boostSearchFieldsAndBoostings,
                                     requestAdapter.getTiebreaker().orElse(DEFAULT_TIEBREAKER),
+                                    requestAdapter.getMultiMatchTiebreaker().orElse(DEFAULT_MULTI_MATCH_TIEBREAKER),
                                     requestAdapter.getTermQueryCache().orElse(null));
 
                     luceneQuery = luceneQueryBuilder.createQuery((querqy.model.Query) boostQuery, factor < 0f);

--- a/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/QueryParsingController.java
+++ b/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/QueryParsingController.java
@@ -376,7 +376,7 @@ public class QueryParsingController {
                             new LuceneQueryBuilder(boostTermQueryBuilder, queryAnalyzer,
                                     boostSearchFieldsAndBoostings,
                                     requestAdapter.getTiebreaker().orElse(DEFAULT_TIEBREAKER),
-                                    requestAdapter.getMultiMatchTiebreaker().orElse(DEFAULT_MULTI_MATCH_TIEBREAKER),
+                                    1f, // we don't have to apply multiMatchTie for boostings
                                     requestAdapter.getTermQueryCache().orElse(null));
 
                     luceneQuery = luceneQueryBuilder.createQuery((querqy.model.Query) boostQuery, factor < 0f);

--- a/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/rewrite/LuceneQueryBuilder.java
+++ b/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/rewrite/LuceneQueryBuilder.java
@@ -19,7 +19,6 @@ import querqy.lucene.rewrite.cache.TermQueryCache;
 import querqy.model.AbstractNodeVisitor;
 import querqy.model.BooleanQuery;
 import querqy.model.BoostedTerm;
-import querqy.model.DisjunctionMaxClause;
 import querqy.model.DisjunctionMaxQuery;
 import querqy.model.MatchAllQuery;
 import querqy.model.QuerqyQuery;

--- a/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/rewrite/LuceneQueryBuilder.java
+++ b/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/rewrite/LuceneQueryBuilder.java
@@ -4,9 +4,7 @@
 package querqy.lucene.rewrite;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.LinkedList;
-import java.util.List;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.BooleanClause.Occur;

--- a/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/rewrite/LuceneQueryFactory.java
+++ b/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/rewrite/LuceneQueryFactory.java
@@ -3,9 +3,8 @@
  */
 package querqy.lucene.rewrite;
 
-import java.io.IOException;
-
 import org.apache.lucene.search.Query;
+import querqy.model.NodeVisitor;
 
 /**
  * @author rene
@@ -15,6 +14,9 @@ public interface LuceneQueryFactory<T extends Query> {
 
     void prepareDocumentFrequencyCorrection(DocumentFrequencyCorrection dfc, boolean isBelowDMQ);
 
-    T createQuery(FieldBoost boost, float dmqTieBreakerMultiplier, TermQueryBuilder termQueryBuilder);
+    T createQuery(FieldBoost boost, TermQueryBuilder termQueryBuilder);
+
+    <R> R accept(LuceneQueryFactoryVisitor<R> visitor);
+
 
 }

--- a/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/rewrite/LuceneQueryFactoryVisitor.java
+++ b/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/rewrite/LuceneQueryFactoryVisitor.java
@@ -1,0 +1,33 @@
+package querqy.lucene.rewrite;
+
+public abstract class LuceneQueryFactoryVisitor<R> {
+
+    public R visit(final BooleanQueryFactory factory) {
+        factory.getClauses().forEach(clause -> clause.queryFactory.accept(this));
+        return null;
+    }
+
+    public R visit(final DisjunctionMaxQueryFactory factory) {
+        factory.disjuncts.forEach(disjunct -> disjunct.accept(this));
+        return null;
+    }
+
+    public R visit(final TermSubQueryFactory factory) {
+        return factory.root.accept(this);
+    }
+
+
+
+    public R visit(final TermQueryFactory factory) {
+        return null;
+    }
+
+
+
+    public R visit(final NeverMatchQueryFactory factory) {
+        return null;
+    }
+
+
+
+}

--- a/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/rewrite/MultiMatchDismaxQueryStructurePostProcessor.java
+++ b/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/rewrite/MultiMatchDismaxQueryStructurePostProcessor.java
@@ -1,0 +1,73 @@
+package querqy.lucene.rewrite;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class MultiMatchDismaxQueryStructurePostProcessor {
+
+    private final float dmqTieBreakerMultiplier;
+    private final float multiMatchTieBreakerMultiplier;
+
+    public MultiMatchDismaxQueryStructurePostProcessor(final float dmqTieBreakerMultiplier,
+                                                       final float multiMatchTieBreakerMultiplier) {
+        this.dmqTieBreakerMultiplier = dmqTieBreakerMultiplier;
+        this.multiMatchTieBreakerMultiplier = multiMatchTieBreakerMultiplier;
+    }
+
+    public LuceneQueryFactory<?> process(final LuceneQueryFactory<?> structure) {
+
+        for (final DisjunctionMaxQueryFactory dmq: TopLevelDmqFinder.findDmqs(structure)) {
+
+            final int numDisjuncts = dmq.getNumberOfDisjuncts();
+            if (numDisjuncts > 1) {
+
+                final Map<Object, List<LuceneQueryFactory<?>>> grouped = dmq.disjuncts.stream()
+                        .collect(Collectors.groupingBy(factory -> {
+                    if (factory instanceof TermSubQueryFactory) {
+                        return ((TermSubQueryFactory) factory).sourceTerm.getValue();
+                    } else if (factory instanceof TermQueryFactory) {
+                        return ((TermQueryFactory) factory).sourceTerm.getValue();
+                    } else return factory;
+
+                }));
+
+                grouped.values().stream()
+                        .filter(factories -> (numDisjuncts > factories.size()) && factories.size() > 1)
+                        .forEach(factories -> {
+                            final DisjunctionMaxQueryFactory group = new DisjunctionMaxQueryFactory(factories,
+                            dmqTieBreakerMultiplier);
+                            factories.forEach(dmq.disjuncts::remove);
+                            dmq.disjuncts.add(group);
+                });
+
+                if (numDisjuncts > dmq.getNumberOfDisjuncts()) {
+                    dmq.setTieBreaker(multiMatchTieBreakerMultiplier);
+                }
+
+            }
+
+
+        }
+        return structure;
+    }
+
+    public final static class TopLevelDmqFinder extends LuceneQueryFactoryVisitor<Void> {
+
+        public static List<DisjunctionMaxQueryFactory> findDmqs(final LuceneQueryFactory<?> structure) {
+            final TopLevelDmqFinder finder = new TopLevelDmqFinder();
+            structure.accept(finder);
+            return finder.dmqs;
+        }
+
+        final List<DisjunctionMaxQueryFactory> dmqs = new LinkedList<>();
+
+        @Override
+        public Void visit(final DisjunctionMaxQueryFactory factory) {
+            dmqs.add(factory);
+            // do not descend to clauses
+            return null;
+        }
+    }
+}

--- a/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/rewrite/MultiMatchDismaxQueryStructurePostProcessor.java
+++ b/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/rewrite/MultiMatchDismaxQueryStructurePostProcessor.java
@@ -5,17 +5,50 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * <p>A post-processor of a structure of {@link LuceneQueryFactory}s that wraps a
+ * {@link org.apache.lucene.search.DisjunctionMaxQuery} around clauses of top-level DisjunctionMaxQuerys that were
+ * created from the same input token.</p>
+ * <p>Let's assume an input query 'asus laptop' and a synonym expansion 'notebook' for laptop, and two query fields
+ * f1 and f2. This gives us DisMax(f1:asus | f2:asus) and DisMax(f1:laptop|f2:laptop|f1:notebook|f2:notebook) as DisMax
+ * queries, each wrapping the term queries that were derived from a common input token. A second level of grouping is
+ * applied per token value. This time we wrap a DisMax query around token values so that the disjunction-maximization of
+ * scores works between fields: DisMax(DisMax(f1:laptop|f2:laptop)|DisMax(f1:notebook|f2:notebook))</p>
+ * <p>Each grouping level comes with its own tie parameter, where the per-value grouping (dmqTieBreakerMultiplier)
+ * corresponds to the tie parameter as it is known from Lucene's dismax, and where the multiMatchTieBreakerMultiplier
+ * is the tie for the newly introduced grouping per input term:
+ * <pre>
+ *     DisMax(f1:asus | f2:asus)~dmqTieBreakerMultiplier
+ *     DisMax(
+ *          DisMax(f1:laptop|f2:laptop)~dmqTieBreakerMultiplier
+ *          |
+ *          DisMax(f1:notebook|f2:notebook)~dmqTieBreakerMultiplier
+ *     )~multiMatchTieBreakerMultiplier
+ * </pre>
+ *
+ */
 public class MultiMatchDismaxQueryStructurePostProcessor {
 
     private final float dmqTieBreakerMultiplier;
     private final float multiMatchTieBreakerMultiplier;
 
+    /**
+     *
+     * @param dmqTieBreakerMultiplier tiebreaker for per-value grouping
+     * @param multiMatchTieBreakerMultiplier - tiebreaker for grouping by input term
+     */
     public MultiMatchDismaxQueryStructurePostProcessor(final float dmqTieBreakerMultiplier,
                                                        final float multiMatchTieBreakerMultiplier) {
         this.dmqTieBreakerMultiplier = dmqTieBreakerMultiplier;
         this.multiMatchTieBreakerMultiplier = multiMatchTieBreakerMultiplier;
     }
 
+    /**
+     * Rewrite the query structure. The operation might manipulate the input query structure and not operate on a copy.
+     *
+     * @param structure The input query structure.
+     * @return The rewritten structure.
+     */
     public LuceneQueryFactory<?> process(final LuceneQueryFactory<?> structure) {
 
         for (final DisjunctionMaxQueryFactory dmq: TopLevelDmqFinder.findDmqs(structure)) {
@@ -53,8 +86,18 @@ public class MultiMatchDismaxQueryStructurePostProcessor {
         return structure;
     }
 
+    /**
+     * Helper class to find the top-level {@link DisjunctionMaxQueryFactory}s in a query tree.
+     */
     public final static class TopLevelDmqFinder extends LuceneQueryFactoryVisitor<Void> {
 
+        /**
+         * Static helper method.
+         *
+         * @param structure The tree structure from which to find the top-level {@link DisjunctionMaxQueryFactory}s
+         *
+         * @return The top-level {@link DisjunctionMaxQueryFactory}s, empty of there aren't any {@link DisjunctionMaxQueryFactory}s in the tree.
+         */
         public static List<DisjunctionMaxQueryFactory> findDmqs(final LuceneQueryFactory<?> structure) {
             final TopLevelDmqFinder finder = new TopLevelDmqFinder();
             structure.accept(finder);

--- a/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/rewrite/NeverMatchQueryFactory.java
+++ b/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/rewrite/NeverMatchQueryFactory.java
@@ -3,8 +3,6 @@
  */
 package querqy.lucene.rewrite;
 
-import java.io.IOException;
-
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 
@@ -22,10 +20,12 @@ public class NeverMatchQueryFactory implements LuceneQueryFactory<Query> {
     }
 
     @Override
-    public Query createQuery(final FieldBoost boostFactor, final float dmqTieBreakerMultiplier,
-                             final TermQueryBuilder termQueryBuilder) {
+    public Query createQuery(final FieldBoost boostFactor, final TermQueryBuilder termQueryBuilder) {
         return new MatchNoDocsQuery();
     }
 
-
+    @Override
+    public <R> R accept(final LuceneQueryFactoryVisitor<R> visitor) {
+        return visitor.visit(this);
+    }
 }

--- a/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/rewrite/SearchFieldsAndBoosting.java
+++ b/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/rewrite/SearchFieldsAndBoosting.java
@@ -4,7 +4,6 @@
 package querqy.lucene.rewrite;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -51,11 +50,11 @@ public class SearchFieldsAndBoosting {
         }
     }
     
-    public Set<String> getSearchFields(Term term) {
-        String fieldname = term.getField();
+    public Set<String> getSearchFields(final Term term) {
+        final String fieldname = term.getField();
         if (fieldname != null) {
             if (term.isGenerated() || queryFieldsAndBoostings.containsKey(fieldname)) {
-                return new HashSet<>(Collections.singletonList(fieldname));
+                return Collections.singleton(fieldname);
             } else {
                 return Collections.emptySet();
             }

--- a/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/rewrite/TermQueryFactory.java
+++ b/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/rewrite/TermQueryFactory.java
@@ -13,10 +13,12 @@ import org.apache.lucene.search.TermQuery;
 public class TermQueryFactory implements LuceneQueryFactory<TermQuery> {
 
     protected final Term term;
+    protected final querqy.model.Term sourceTerm;
    
-    public TermQueryFactory(final Term term) {
-       this.term = term;
-   }
+    public TermQueryFactory(final Term term, final querqy.model.Term sourceTerm) {
+        this.term = term;
+        this.sourceTerm = sourceTerm;
+    }
 
     @Override
     public void prepareDocumentFrequencyCorrection(final DocumentFrequencyCorrection dfc, final boolean isBelowDMQ) {
@@ -29,18 +31,17 @@ public class TermQueryFactory implements LuceneQueryFactory<TermQuery> {
 
         dfc.prepareTerm(term);
 
-
-
     }
 
     @Override
-    public TermQuery createQuery(final FieldBoost boost, final float dmqTieBreakerMultiplier,
-                                 final TermQueryBuilder termQueryBuilder) {
+    public TermQuery createQuery(final FieldBoost boost, final TermQueryBuilder termQueryBuilder) {
 
         return termQueryBuilder.createTermQuery(term, boost);
 
     }
 
-
-
+    @Override
+    public <R> R accept(final LuceneQueryFactoryVisitor<R> visitor) {
+        return visitor.visit(this);
+    }
 }

--- a/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/rewrite/TermSubQueryFactory.java
+++ b/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/rewrite/TermSubQueryFactory.java
@@ -3,11 +3,10 @@
  */
 package querqy.lucene.rewrite;
 
-import java.io.IOException;
-
 import org.apache.lucene.search.Query;
 
 import querqy.lucene.rewrite.prms.PRMSQuery;
+import querqy.model.Term;
 
 /**
  * A LuceneQueryFactory that wraps a TermQueryFactory or the factory of a more complex
@@ -21,15 +20,19 @@ public class TermSubQueryFactory implements LuceneQueryFactory<Query> {
     final LuceneQueryFactory<?> root;
     final FieldBoost boost;
     public final PRMSQuery prmsQuery;
+    final Term sourceTerm;
     
-    public TermSubQueryFactory(final LuceneQueryFactoryAndPRMSQuery rootAndPrmsQuery, final FieldBoost boost) {
-        this(rootAndPrmsQuery.queryFactory, rootAndPrmsQuery.prmsQuery, boost);
+    public TermSubQueryFactory(final LuceneQueryFactoryAndPRMSQuery rootAndPrmsQuery, final FieldBoost boost,
+                               final Term sourceTerm) {
+        this(rootAndPrmsQuery.queryFactory, rootAndPrmsQuery.prmsQuery, boost, sourceTerm);
     }
     
-    public TermSubQueryFactory(final LuceneQueryFactory<?> root, final PRMSQuery prmsQuery, final FieldBoost boost) {
+    public TermSubQueryFactory(final LuceneQueryFactory<?> root, final PRMSQuery prmsQuery, final FieldBoost boost,
+                               final Term sourceTerm) {
         this.root = root;
         this.boost = boost;
         this.prmsQuery = prmsQuery;
+        this.sourceTerm = sourceTerm;
     }
 
     @Override
@@ -38,16 +41,17 @@ public class TermSubQueryFactory implements LuceneQueryFactory<Query> {
     }
 
     @Override
-    public Query createQuery(final FieldBoost boost, final float dmqTieBreakerMultiplier,
-                             final TermQueryBuilder termQueryBuilder) {
+    public Query createQuery(final FieldBoost boost, final TermQueryBuilder termQueryBuilder) {
         
-        return root.createQuery(
-                this.boost, 
-                dmqTieBreakerMultiplier,         
-                termQueryBuilder);
+        return root.createQuery(this.boost, termQueryBuilder);
     }
     
     public boolean isNeverMatchQuery() {
         return root instanceof NeverMatchQueryFactory;
+    }
+
+    @Override
+    public <R> R accept(final LuceneQueryFactoryVisitor<R> visitor) {
+        return visitor.visit(this);
     }
 }

--- a/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/rewrite/AbstractLuceneQueryTest.java
+++ b/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/rewrite/AbstractLuceneQueryTest.java
@@ -1,5 +1,6 @@
 package querqy.lucene.rewrite;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -329,10 +330,15 @@ public class AbstractLuceneQueryTest {
           if (fieldBoost == null) {
               return false;
           }
-          if (fieldBoost != null && fieldBoost instanceof IndependentFieldBoost) {
-              return boost == ((IndependentFieldBoost) fieldBoost).getBoost(term.field());
+          if (fieldBoost instanceof IndependentFieldBoost || fieldBoost instanceof BoostedDelegatingFieldBoost) {
+              try {
+                  return boost == fieldBoost.getBoost(term.field(), null);
+              } catch (final IOException e) {
+                  throw new RuntimeException(e);
+              }
           } else {
-              throw new RuntimeException("Cannot test FieldBoosts other than IndependentFieldBoost");
+              throw new RuntimeException("Cannot test FieldBoosts other than IndependentFieldBoost and " +
+                      "BoostedDelegatingFieldBoost");
           }
                 
        }

--- a/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/rewrite/LuceneQueryBuilderTest.java
+++ b/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/rewrite/LuceneQueryBuilderTest.java
@@ -323,7 +323,7 @@ public class LuceneQueryBuilderTest extends AbstractLuceneQueryTest {
                   dtq(Occur.MUST, 1f, "f1", "s"),
                   dtq(Occur.MUST, 1f, "f1", "t")
             ),
-            dtq(1f, "f1", "q")
+            dtq(0.2f, "f1", "q")
             ));
    }
 
@@ -351,8 +351,8 @@ public class LuceneQueryBuilderTest extends AbstractLuceneQueryTest {
                                                 dtq(2f, "f2", "t")
                                         )
                                 ),
-                                dtq(1f, "f1", "q"),
-                                dtq(2f, "f2", "q")
+                                dtq(0.2f, "f1", "q"), // synonym weight is 0.2
+                                dtq(0.2f*2f, "f2", "q") // synonym = 0.2, field weight = 2
                         )
                 )
         );
@@ -389,8 +389,8 @@ public class LuceneQueryBuilderTest extends AbstractLuceneQueryTest {
                                         )
                                 ),
                                 dmq(1f, tie,
-                                        dtq(1f, "f1", "q"),
-                                        dtq(2f, "f2", "q")
+                                        dtq(0.2f, "f1", "q"), // synonym weight is 0.2
+                                        dtq(0.2f*2f, "f2", "q") // synonym = 0.2, field weight = 2
 
                                 )
                         )
@@ -449,8 +449,8 @@ public class LuceneQueryBuilderTest extends AbstractLuceneQueryTest {
                                         )
                                 ),
                                 dmq(1f, tie,
-                                        dtq(1f, "f1", "q"),
-                                        dtq(2f, "f2", "q")
+                                        dtq(0.2f, "f1", "q"), // synonym weight is 0.2
+                                        dtq(0.2f*2f, "f2", "q") // synonym = 0.2, field weight = 2
 
                                 )
                         )

--- a/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/rewrite/TermSubQueryBuilderTest.java
+++ b/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/rewrite/TermSubQueryBuilderTest.java
@@ -43,10 +43,10 @@ public class TermSubQueryBuilderTest {
         TermSubQueryBuilder builder = new TermSubQueryBuilder(ANALYZER, null);
         
         PositionSequence<org.apache.lucene.index.Term> sequence = new PositionSequence<>();
-        assertNull(builder.positionSequenceToQueryFactoryAndPRMS(sequence));
+        assertNull(builder.positionSequenceToQueryFactoryAndPRMS(sequence, null));
 
         sequence.nextPosition();
-        assertNull(builder.positionSequenceToQueryFactoryAndPRMS(sequence));
+        assertNull(builder.positionSequenceToQueryFactoryAndPRMS(sequence, null));
     }
     
     @Test
@@ -60,7 +60,8 @@ public class TermSubQueryBuilderTest {
         sequence.addElement(term);
         
         
-        LuceneQueryFactoryAndPRMSQuery lap = builder.positionSequenceToQueryFactoryAndPRMS(sequence);
+        LuceneQueryFactoryAndPRMSQuery lap = builder.positionSequenceToQueryFactoryAndPRMS(sequence,
+                new querqy.model.Term(null, "a"));
         
         assertThat(
                 lap,
@@ -83,7 +84,8 @@ public class TermSubQueryBuilderTest {
         Term term2 = new Term("f", "b");
         sequence.addElement(term2);
         
-        LuceneQueryFactoryAndPRMSQuery lap = builder.positionSequenceToQueryFactoryAndPRMS(sequence);
+        LuceneQueryFactoryAndPRMSQuery lap = builder.positionSequenceToQueryFactoryAndPRMS(sequence,
+                new querqy.model.Term(null, "ab"));
         assertThat(
                 lap,
                 lap(
@@ -115,7 +117,8 @@ public class TermSubQueryBuilderTest {
         Term term2 = new Term("f", "b");
         sequence.addElement(term2);
         
-        LuceneQueryFactoryAndPRMSQuery lap = builder.positionSequenceToQueryFactoryAndPRMS(sequence);
+        LuceneQueryFactoryAndPRMSQuery lap = builder.positionSequenceToQueryFactoryAndPRMS(sequence,
+                new querqy.model.Term(null, "ab"));
         assertThat(
                 lap,
                 lap(
@@ -132,7 +135,7 @@ public class TermSubQueryBuilderTest {
     }
     
     @Test
-    public void testTwoTermsAtFirstAndOneTermAtSecondPosition() throws Exception {
+    public void testTwoTermsAtFirstAndOneTermAtSecondPosition()  {
         
         TermSubQueryBuilder builder = new TermSubQueryBuilder(ANALYZER, null);
         
@@ -150,7 +153,8 @@ public class TermSubQueryBuilderTest {
         Term term2 = new Term("f", "b");
         sequence.addElement(term2);
         
-        LuceneQueryFactoryAndPRMSQuery lap = builder.positionSequenceToQueryFactoryAndPRMS(sequence);
+        LuceneQueryFactoryAndPRMSQuery lap = builder.positionSequenceToQueryFactoryAndPRMS(sequence,
+                new querqy.model.Term(null, "a1b"));
         assertThat(
                 lap,
                 lap(

--- a/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/rewrite/prms/PRMSAndQueryTest.java
+++ b/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/rewrite/prms/PRMSAndQueryTest.java
@@ -86,7 +86,7 @@ public class PRMSAndQueryTest extends LuceneTestCase {
                 fields, 0.8f);
         
         LuceneQueryBuilder queryBuilder = new LuceneQueryBuilder(new DependentTermQueryBuilder(dfc), analyzer,
-                searchFieldsAndBoosting, 0.01f, null);
+                searchFieldsAndBoosting, 0.01f, 1f, null);
         
         WhiteSpaceQuerqyParser parser = new WhiteSpaceQuerqyParser();
         

--- a/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/rewrite/prms/PRMSDisjunctionMaxQueryTest.java
+++ b/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/rewrite/prms/PRMSDisjunctionMaxQueryTest.java
@@ -108,7 +108,7 @@ public class PRMSDisjunctionMaxQueryTest extends LuceneTestCase {
         SearchFieldsAndBoosting searchFieldsAndBoosting = new SearchFieldsAndBoosting(FieldBoostModel.PRMS, fields, fields, 0.8f);
         
         LuceneQueryBuilder queryBuilder = new LuceneQueryBuilder(new DependentTermQueryBuilder(dfc), queryAnalyzer,
-                searchFieldsAndBoosting, 0.01f, null);
+                searchFieldsAndBoosting, 0.01f, 1f, null);
         
         WhiteSpaceQuerqyParser parser = new WhiteSpaceQuerqyParser();
         

--- a/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/rewrite/prms/PRMSFieldBoostTest.java
+++ b/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/rewrite/prms/PRMSFieldBoostTest.java
@@ -64,7 +64,7 @@ public class PRMSFieldBoostTest extends LuceneTestCase {
         SearchFieldsAndBoosting searchFieldsAndBoosting = new SearchFieldsAndBoosting(FieldBoostModel.PRMS, fields, fields, 0.8f);
         
         LuceneQueryBuilder queryBuilder = new LuceneQueryBuilder(new DependentTermQueryBuilder(dfc), analyzer,
-                searchFieldsAndBoosting, 0.01f, null);
+                searchFieldsAndBoosting, 0.01f, 1f, null);
         
         WhiteSpaceQuerqyParser parser = new WhiteSpaceQuerqyParser();
         

--- a/querqy-for-lucene/querqy-lucene/src/test/resources/rules-synonyms.txt
+++ b/querqy-for-lucene/querqy-lucene/src/test/resources/rules-synonyms.txt
@@ -25,3 +25,6 @@ g h =>
 j =>
     SYNONYM: s t
     SYNONYM: q
+
+100-2 =>
+    SYNONYM: onehundreddashtwo

--- a/querqy-for-lucene/querqy-lucene/src/test/resources/rules-synonyms.txt
+++ b/querqy-for-lucene/querqy-lucene/src/test/resources/rules-synonyms.txt
@@ -24,7 +24,7 @@ g h =>
 
 j =>
     SYNONYM: s t
-    SYNONYM: q
+    SYNONYM(0.2): q
 
 100-2 =>
     SYNONYM: onehundreddashtwo

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/DismaxSearchEngineRequestAdapter.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/DismaxSearchEngineRequestAdapter.java
@@ -201,7 +201,10 @@ public class DismaxSearchEngineRequestAdapter implements LuceneSearchEngineReque
         return getFloatRequestParam(TIE);
     }
 
-
+    @Override
+    public Optional<Float> getMultiMatchTiebreaker() {
+        return getFloatRequestParam(MULTI_MATCH_TIE);
+    }
 
     @Override
     public boolean isDebugQuery() {

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyDismaxParams.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/QuerqyDismaxParams.java
@@ -168,6 +168,20 @@ public interface QuerqyDismaxParams {
     String TIE = "tie";
 
     /**
+     * <p>A tiebreak multiplier to control how the scores of added clauses that go back to a single user query clause
+     * are combined.</p><p>Let's say we have a query &quot;asus laptop&quot;, a synonym expansion &quot;laptop =&gt;
+     * notebook&quot; and &quot;qf=f1 f2&quot; then the resulting query would look like this:
+     * <pre>
+     *     asus ((f1:laptop | f2:laptop)~tie | (f1:notebook | f2:notebook)~tie)~multiMatchTie
+     * </pre>
+     * where <i>tie</i> is taken from the parameter of the same name. A <i>multiMatchTie</i> value of 0 means that only
+     * the maximum score of the alternatives will be used. A value of 1.0 means that scores will just be summed up. A
+     * value between 0 and 1 means that the maximum score will be summed up with the other scores, which will be
+     * multiplied with the value of <i>multiMatchTie</i>.</p>
+     */
+    String MULTI_MATCH_TIE = "multiMatchTie";
+
+    /**
      * Same as {@link org.apache.solr.common.params.DisMaxParams#QF}
      */
     String QF = "qf";

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/TermQueryCachePreloader.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/TermQueryCachePreloader.java
@@ -141,7 +141,7 @@ public class TermQueryCachePreloader extends AbstractSolrEventListener implement
             // no need to re-test for hits if we've seen this term before
             if (testForHits && (termSubQueryFactory != null) && (!termSubQueryFactory.isNeverMatchQuery())) {
                 final Query query = termSubQueryFactory
-                        .createQuery(ConstantFieldBoost.NORM_BOOST, 0.01f, new LuceneTermQueryBuilder());
+                        .createQuery(ConstantFieldBoost.NORM_BOOST, new LuceneTermQueryBuilder());
                 final TopDocs topDocs = searcher.search(query, 1);
                 if (topDocs.totalHits.value < 1) {
                     cache.put(new CacheKey(field, term),

--- a/querqy-for-lucene/querqy-solr/src/test/resources/configs/commonrules/rules-QuerqyDismaxQParserTest.txt
+++ b/querqy-for-lucene/querqy-solr/src/test/resources/configs/commonrules/rules-QuerqyDismaxQParserTest.txt
@@ -54,6 +54,9 @@ gg =>
 hh =>
    UP(1000): xx -vv
 
+x1 =>
+   SYNONYM: x2
+   SYNONYM: x3
 
 
 


### PR DESCRIPTION
This implements #281. 

The implementation adds a new parameter `multiMatchTie`. If multiMatchTie < 1.0, a dismax query is added to produce the query structure described in the comments on issue #281. As a result, if for example, an input query `laptop` is expanded into `laptop or notebook` the dismax aggregates the scores of the two terms. If multiMatchTie=0 only the max score will be used while the 'old' `tie` param is still applied to field matches (f1:laptop | f2:laptop).

At what stage is the new dismax query added? In general, we transform queries in several steps:

`(user query string) => (Querqy object model) => (Lucene Query Factories) => (Lucene Query)`

The new dismax is added here:

`(Lucene Query Factories) -> Add dismax within Lucene Query Factory structure => (Lucene Query)`

(see querqy.lucene.rewrite.MultiMatchDismaxQueryStructurePostProcessor)

Doing it at this late stage has the advantage that we already know the Lucene structure of the query - all field names have been applied and the analysis chain will not delete any term later. Doing it within  `(Querqy object model)` wasn't possible within the current model design (a Dismax cannot be a child query of a Dismax parent). I can also imagine that we will introduce further  `PostProcessor`s, for example for optimising the query by removing duplicate tokens that where created independently by two rewriters.

I've added a visitor pattern to Lucene Query Factories for easier navigation of the query tree.