### PR TITLE
Stopwords testing

### DIFF
--- a/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/QuerqyDismaxQParserPluginWithStopwordsTest.java
+++ b/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/QuerqyDismaxQParserPluginWithStopwordsTest.java
@@ -4,6 +4,7 @@ import static querqy.solr.QuerqyQParserPlugin.PARAM_REWRITERS;
 import static querqy.solr.StandaloneSolrTestSupport.withCommonRulesRewriter;
 
 import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.DisMaxParams;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.search.QueryParsing;
@@ -15,18 +16,13 @@ import org.junit.Test;
 public class QuerqyDismaxQParserPluginWithStopwordsTest extends SolrTestCaseJ4 {
 
     public void index() {
-
-        assertU(adoc("id", "1", "f1_stopwords", "a", "f2_stopwords", "c"));
-
-        assertU(adoc("id", "2", "f1_stopwords", "a", "f2_stopwords", "b"));
-        
-        assertU(adoc("id", "3", "f1_stopwords", "a", "f3", "c"));
-        
-        assertU(adoc("id", "4", "f3", "stopA"));
+        assertU(adoc("id", "1", "f1", "a"));
+        assertU(adoc("id", "2", "f1", "a"));
+        assertU(adoc("id", "3", "f1", "a"));
+        assertU(adoc("id", "4", "f1", "stopA"));
 
         assertU(commit());
-
-     }
+    }
 
     @BeforeClass
     public static void beforeTests() throws Exception {
@@ -41,25 +37,148 @@ public class QuerqyDismaxQParserPluginWithStopwordsTest extends SolrTestCaseJ4 {
         clearIndex();
         index();
     }
-     
+
     @Test
-    public void testThatStopwordOnlyQueryReturnsNoResult() {
-
-        String q = "stopA";
-
+    public void testQueryWithStopwords() {
+        // Simple test make sure data loaded
+        String q = "a";
         SolrQueryRequest req = req("q", q,
-                DisMaxParams.QF, "f1_stopwords f2_stopwords",
+                DisMaxParams.QF, "id f1",
+                QueryParsing.OP, "OR",
+                DisMaxParams.TIE, "0.1",
+                "defType", "edismax",
+                PARAM_REWRITERS, "common_rules_empty",
+                CommonParams.DEBUG, "true",
+                "indent", "true"
+        );
+        assertQ("Expected 3 results",
+                req,
+                "//result[@name='response'][@numFound='3']");
+
+        req.close();
+
+        q = "a";
+        req = req("q", q,
+                DisMaxParams.QF, "id f1",
                 QueryParsing.OP, "OR",
                 DisMaxParams.TIE, "0.1",
                 "defType", "querqy",
                 PARAM_REWRITERS, "common_rules_empty",
-                "debugQuery", "true"
-              );
-        assertQ("No results expected",
-              req,
-              "//result[@name='response'][@numFound='0']");
+                CommonParams.DEBUG, "true",
+                "indent", "true"
+        );
+        assertQ("Expected 3 results",
+                req,
+                "//result[@name='response'][@numFound='3']");
 
         req.close();
-     }
+
+
+        // Check that no documents are found for only stop word
+        q = "stopA";
+
+        req = req("q", q,
+                DisMaxParams.QF, "id f1",
+                QueryParsing.OP, "OR",
+                DisMaxParams.TIE, "0.1",
+                "defType", "edismax",
+                PARAM_REWRITERS, "common_rules_empty",
+                CommonParams.DEBUG, "true",
+                "indent", "true"
+        );
+        assertQ("No results expected",
+                req,
+                "//result[@name='response'][@numFound='0']");
+
+        req.close();
+
+        q = "stopA";
+
+        req = req("q", q,
+                DisMaxParams.QF, "id f1",
+                QueryParsing.OP, "OR",
+                DisMaxParams.TIE, "0.1",
+                "defType", "querqy",
+                PARAM_REWRITERS, "common_rules_empty",
+                CommonParams.DEBUG, "true",
+                "indent", "true"
+        );
+        assertQ("No results expected",
+                req,
+                "//result[@name='response'][@numFound='0']");
+
+        req.close();
+
+        // Test mix stop words and regular work without mm
+        q = "stopA a";
+
+        req = req("q", q,
+                DisMaxParams.QF, "id f1",
+                QueryParsing.OP, "OR",
+                DisMaxParams.TIE, "0.1",
+                "defType", "edismax",
+                PARAM_REWRITERS, "common_rules_empty",
+                CommonParams.DEBUG, "true",
+                "indent", "true"
+        );
+        assertQ("Expected 3 results",
+                req,
+                "//result[@name='response'][@numFound='3']");
+
+        req.close();
+
+        q = "stopA a";
+
+        req = req("q", q,
+                DisMaxParams.QF, "id f1",
+                QueryParsing.OP, "OR",
+                DisMaxParams.TIE, "0.1",
+                "defType", "querqy",
+                PARAM_REWRITERS, "common_rules_empty",
+                CommonParams.DEBUG, "true",
+                "indent", "true"
+        );
+        assertQ("Expected 3 results",
+                req,
+                "//result[@name='response'][@numFound='3']");
+
+        req.close();
+
+        // Test mix stop words and regular work with mm
+
+        q = "stopA a";
+
+        req = req("q", q,
+                DisMaxParams.QF, "id f1",
+                QueryParsing.OP, "OR",
+                DisMaxParams.MM, "2",
+                "defType", "edismax",
+                PARAM_REWRITERS, "common_rules_empty",
+                CommonParams.DEBUG, "true",
+                "indent", "true"
+        );
+        assertQ("Expected 3 results",
+                req,
+                "//result[@name='response'][@numFound='3']");
+
+        req.close();
+
+        q = "stopA a";
+
+        req = req("q", q,
+                DisMaxParams.QF, "id f1",
+                QueryParsing.OP, "OR",
+                DisMaxParams.MM, "2",
+                "defType", "querqy",
+                PARAM_REWRITERS, "common_rules_empty",
+                CommonParams.DEBUG, "true",
+                "indent", "true"
+        );
+        assertQ("Expected 3 results",
+                req,
+                "//result[@name='response'][@numFound='3']");
+
+        req.close();
+    }
 
 }

--- a/querqy-for-lucene/querqy-solr/src/test/resources/solr/collection1/conf/schema-stopwords.xml
+++ b/querqy-for-lucene/querqy-solr/src/test/resources/solr/collection1/conf/schema-stopwords.xml
@@ -1,28 +1,16 @@
 <?xml version="1.0" ?>
 <schema name="minimal test schema" version="1.5">
-
    <fieldtype name="string"  class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
-   <fieldType name="long" class="solr.TrieLongField" precisionStep="0" positionIncrementGap="0"/>
-   <fieldType name="text_stopwords" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" words="stopwords.txt" ignoreCase="false"/>
-      </analyzer>
-    </fieldType>
-    
    <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.StopFilterFactory" words="stopwords.txt" ignoreCase="false"/>
       </analyzer>
-    </fieldType>
+   </fieldType>
  
   <field name="id"        type="string" indexed="true"  stored="true"  multiValued="false" required="true"/>
-  <field name="f1_stopwords"  type="text_stopwords"   indexed="true"  stored="true"  multiValued="false" /> 
-  <field name="f2_stopwords"        type="text_stopwords"   indexed="true"  stored="true"  multiValued="false" /> 
-  <field name="f3"        type="text"   indexed="true"  stored="true"  multiValued="false" /> 
+  <field name="f1"        type="text"   indexed="true"  stored="true"  multiValued="false" />
 
- <uniqueKey>id</uniqueKey>
-
+  <uniqueKey>id</uniqueKey>
 </schema>
 


### PR DESCRIPTION
If there are stopwords when using Querqy and minimum should match, end up in the scenario where a single term query works but when you add a stop word it fails. This is a behavior change compared to `edismax`.

No fix is pushed here just a failing test.

Based on the `parsedquery` debug:
```
// edismax generates: +DisjunctionMaxQuery((((id:stopA id:a)~2) | f1:a))
// querqy generates: (id:stopA DisjunctionMaxQuery((id:a | f1:a)))~2
```