### PR TITLE
Fixes #346

### DIFF
--- a/querqy-core/src/main/java/querqy/rewrite/QuerqyTemplateEngine.java
+++ b/querqy-core/src/main/java/querqy/rewrite/QuerqyTemplateEngine.java
@@ -1,5 +1,7 @@
 package querqy.rewrite;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -105,7 +107,7 @@ public class QuerqyTemplateEngine {
                     writeLine(outputStream, line, originalLineNumberMapping.get(lineNumber), lineNumberMapping);
                 }
             }
-            return new RenderedRules(new InputStreamReader(new ByteArrayInputStream(outputStream.toByteArray())),
+            return new RenderedRules(new InputStreamReader(new ByteArrayInputStream(outputStream.toByteArray()), UTF_8),
                     lineNumberMapping);
         }
     }
@@ -123,7 +125,7 @@ public class QuerqyTemplateEngine {
                            final String line,
                            final int originalLineNumber,
                            final Map<Integer, Integer> lineNumberMapping) throws IOException {
-        outputStream.write(line.getBytes());
+        outputStream.write(line.getBytes(UTF_8));
         outputStream.write(LINE_BREAK);
         lineNumberMapping.put(lineNumberMapping.size() + 1, originalLineNumber);
     }
@@ -234,13 +236,13 @@ public class QuerqyTemplateEngine {
 
                     this.templates.put(templateName, new Template(templateName, parameters, templateBody));
                 } else {
-                    outputStream.write(line.getBytes());
+                    outputStream.write(line.getBytes(UTF_8));
                     outputStream.write(LINE_BREAK);
                     lineNumberMapping.put(lineNumberMapping.size() + 1, lineNumber);
                 }
             }
 
-            return new RenderedRules(new InputStreamReader(new ByteArrayInputStream(outputStream.toByteArray())),
+            return new RenderedRules(new InputStreamReader(new ByteArrayInputStream(outputStream.toByteArray()), UTF_8),
                     lineNumberMapping);
         }
     }

--- a/querqy-core/src/main/java/querqy/rewrite/experimental/QueryRewritingHandler.java
+++ b/querqy-core/src/main/java/querqy/rewrite/experimental/QueryRewritingHandler.java
@@ -1,5 +1,7 @@
 package querqy.rewrite.experimental;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import querqy.model.ExpandedQuery;
 import querqy.model.convert.builder.ExpandedQueryBuilder;
 import querqy.parser.QuerqyParser;
@@ -74,11 +76,11 @@ public class QueryRewritingHandler {
 
         // TODO: Replace these methods by a method addRewriterFactoryBuilder(...) and by builders in the respective
         //  factories
-        public QueryRewritingHandler.Builder addReplaceRewriter(final String config) throws IOException {
+        public QueryRewritingHandler.Builder addReplaceRewriter(final String rules) throws IOException {
             final String rewriterId = "querqy_replace_" + this.rewriterIdCounter++;
             rewriterFactories.add(new ReplaceRewriterFactory(
                     rewriterId,
-                    new InputStreamReader(new ByteArrayInputStream(config.getBytes())),
+                    new InputStreamReader(new ByteArrayInputStream(rules.getBytes(UTF_8)), UTF_8),
                     true,
                     "\t",
                     new WhiteSpaceQuerqyParserFactory().createParser()));
@@ -86,11 +88,11 @@ public class QueryRewritingHandler {
             return this;
         }
 
-        public QueryRewritingHandler.Builder addCommonRulesRewriter(final String config) throws IOException {
+        public QueryRewritingHandler.Builder addCommonRulesRewriter(final String rules) throws IOException {
             final String rewriterId = "querqy_commonrules_" + this.rewriterIdCounter++;
             rewriterFactories.add(new SimpleCommonRulesRewriterFactory(
                     rewriterId,
-                    new StringReader(config),
+                    new StringReader(rules),
                     true,
                     BoostMethod.ADDITIVE,
                     new WhiteSpaceQuerqyParserFactory(),

--- a/querqy-core/src/test/java/querqy/rewrite/QuerqyTemplateEngineTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/QuerqyTemplateEngineTest.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class QuerqyTemplateEngineTest {
@@ -92,7 +93,7 @@ public class QuerqyTemplateEngineTest {
     }
 
     private Reader resource(String resourceName) {
-        return new InputStreamReader(getClass().getClassLoader().getResourceAsStream(resourceName));
+        return new InputStreamReader(getClass().getClassLoader().getResourceAsStream(resourceName), UTF_8);
     }
 
     private List<String> list(Reader reader) throws IOException {

--- a/querqy-core/src/test/java/querqy/rewrite/commonrules/SimpleParserTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/commonrules/SimpleParserTest.java
@@ -1,5 +1,6 @@
 package querqy.rewrite.commonrules;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.not;
@@ -44,7 +45,7 @@ public class SimpleParserTest extends AbstractCommonRulesTest {
     }
 
     SimpleCommonRulesParser createParserFromResource(String resourceName, boolean ignoreCase) {
-        reader = new InputStreamReader(getClass().getClassLoader().getResourceAsStream(resourceName));
+        reader = new InputStreamReader(getClass().getClassLoader().getResourceAsStream(resourceName), UTF_8);
         return new SimpleCommonRulesParser(reader, true, querqyParserFactory, ignoreCase, BoostMethod.ADDITIVE);
     }
 

--- a/querqy-core/src/test/java/querqy/rewrite/contrib/replace/ReplaceRewriterParserTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/contrib/replace/ReplaceRewriterParserTest.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ReplaceRewriterParserTest {
@@ -101,7 +102,7 @@ public class ReplaceRewriterParserTest {
     }
 
     private ReplaceRewriterParser createParser(String rules, boolean ignoreCase) {
-        InputStreamReader input = new InputStreamReader(new ByteArrayInputStream(rules.getBytes()));
+        InputStreamReader input = new InputStreamReader(new ByteArrayInputStream(rules.getBytes(UTF_8)), UTF_8);
         return new ReplaceRewriterParser(
                 input, ignoreCase, "\t", new WhiteSpaceQuerqyParser());
     }
@@ -128,7 +129,7 @@ public class ReplaceRewriterParserTest {
                 + " abc* => ae \n"
                 + " ab* => af \n";
 
-        InputStreamReader input = new InputStreamReader(new ByteArrayInputStream(rules.getBytes()));
+        InputStreamReader input = new InputStreamReader(new ByteArrayInputStream(rules.getBytes(UTF_8)), UTF_8);
         ReplaceRewriterParser replaceRewriterParser = new ReplaceRewriterParser(
                 input, true, "\t", new WhiteSpaceQuerqyParser());
 

--- a/querqy-core/src/test/java/querqy/rewrite/rules/ParserMigrationTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/rules/ParserMigrationTest.java
@@ -38,6 +38,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static querqy.rewrite.commonrules.model.BoostInstruction.BoostMethod.ADDITIVE;
 
@@ -173,7 +174,7 @@ public class ParserMigrationTest {
 
     private Reader reader(final String filePath) {
         final InputStream is = getClass().getClassLoader().getResourceAsStream(BASE_PATH + filePath);
-        return new BufferedReader(new InputStreamReader(is));
+        return new BufferedReader(new InputStreamReader(is, UTF_8));
     }
 
 

--- a/querqy-for-lucene/pom.xml
+++ b/querqy-for-lucene/pom.xml
@@ -147,6 +147,9 @@
                     <systemPropertyVariables>
                         <tests.codec>Lucene90</tests.codec>
                         <java.security.egd>file:/dev/./urandom</java.security.egd>
+                        <!-- Use narrow US-ASCII as default Java character set (via file.encoding system property)
+                        to increase the chance of catching code that relies on the JDK default encoding -->
+                        <argLine>-Dfile.encoding=US-ASCII</argLine>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/GZIPAwareResourceLoaderTest.java
+++ b/querqy-for-lucene/querqy-lucene/src/test/java/querqy/lucene/GZIPAwareResourceLoaderTest.java
@@ -1,5 +1,6 @@
 package querqy.lucene;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -45,7 +46,7 @@ public class GZIPAwareResourceLoaderTest {
 
         final GZIPAwareResourceLoader loader = new GZIPAwareResourceLoader(resourceLoader);
         try (final BufferedReader reader = new BufferedReader(
-                new InputStreamReader(loader.openResource("some_name")))) {
+                new InputStreamReader(loader.openResource("some_name"), UTF_8))) {
             assertEquals("HELLO QUERQY!", reader.readLine());
             assertNull(reader.readLine());
         }
@@ -62,7 +63,7 @@ public class GZIPAwareResourceLoaderTest {
 
         final GZIPAwareResourceLoader loader = new GZIPAwareResourceLoader(resourceLoader);
         try (final BufferedReader reader = new BufferedReader(
-                new InputStreamReader(loader.openResource("some_name")))) {
+                new InputStreamReader(loader.openResource("some_name"), UTF_8))) {
 
             assertEquals("HELLO, I wasn't zipped!", reader.readLine());
             assertNull(reader.readLine());

--- a/querqy-for-lucene/querqy-solr/pom.xml
+++ b/querqy-for-lucene/querqy-solr/pom.xml
@@ -122,6 +122,9 @@
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <excludedGroups>querqy.solr.it.IntegrationTest</excludedGroups>
+                    <!-- Use narrow US-ASCII as default Java character set (via file.encoding system property)
+                         to increase the chance of catching code that relies on the JDK default encoding -->
+                    <argLine>-Dfile.encoding=US-ASCII</argLine>
                 </configuration>
             </plugin>
 

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/ZkRewriterContainer.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/ZkRewriterContainer.java
@@ -1,5 +1,6 @@
 package querqy.solr;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static querqy.solr.utils.JsonUtil.*;
 
 import org.apache.solr.cloud.ZkController;
@@ -163,7 +164,7 @@ public class ZkRewriterContainer extends RewriterContainer<ZkSolrResourceLoader>
 
         try {
 
-            final byte[] infoData = new RewriterStorageInfo(uuids, dataDirectory).toJsonString().getBytes();
+            final byte[] infoData = new RewriterStorageInfo(uuids, dataDirectory).toJsonString().getBytes(UTF_8);
 
             if (stat == null) {
 

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/rewriter/commonrules/CommonRulesConfigRequestBuilder.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/rewriter/commonrules/CommonRulesConfigRequestBuilder.java
@@ -1,5 +1,7 @@
 package querqy.solr.rewriter.commonrules;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import querqy.rewrite.commonrules.QuerqyParserFactory;
 import querqy.rewrite.commonrules.model.BoostInstruction;
 import querqy.rewrite.commonrules.select.SelectionStrategyFactory;
@@ -56,7 +58,7 @@ public class CommonRulesConfigRequestBuilder extends RewriterConfigRequestBuilde
     }
 
     public CommonRulesConfigRequestBuilder rules(final InputStream inputStream) throws IOException {
-        try (final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
+        try (final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, UTF_8))) {
             rules = reader.lines().collect(Collectors.joining("\n"));
         }
         return this;

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/rewriter/replace/ReplaceConfigRequestBuilder.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/rewriter/replace/ReplaceConfigRequestBuilder.java
@@ -1,5 +1,7 @@
 package querqy.solr.rewriter.replace;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import querqy.rewrite.commonrules.QuerqyParserFactory;
 import querqy.solr.RewriterConfigRequestBuilder;
 
@@ -57,7 +59,7 @@ public class ReplaceConfigRequestBuilder extends RewriterConfigRequestBuilder {
     }
 
     public ReplaceConfigRequestBuilder rules(final InputStream inputStream) throws IOException {
-        try (final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
+        try (final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, UTF_8))) {
             rules = reader.lines().collect(Collectors.joining("\n"));
         }
         return this;

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/rewriter/replace/ReplaceRewriterFactory.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/rewriter/replace/ReplaceRewriterFactory.java
@@ -45,7 +45,7 @@ public class ReplaceRewriterFactory extends SolrRewriterFactoryAdapter implement
     @Override
     public void configure(final Map<String, Object> config) {
         final String rules = (String) config.get(CONF_RULES);
-        final InputStreamReader rulesReader = new InputStreamReader(new ByteArrayInputStream(rules.getBytes()));
+        final InputStreamReader rulesReader = new InputStreamReader(new ByteArrayInputStream(rules.getBytes(UTF_8)), UTF_8);
 
         final boolean ignoreCase = ConfigUtils.getArg(config, CONF_IGNORE_CASE, DEFAULT_IGNORE_CASE);
 
@@ -70,7 +70,7 @@ public class ReplaceRewriterFactory extends SolrRewriterFactoryAdapter implement
             return Collections.singletonList("Property '" + CONF_RULES + "' not configured");
         }
 
-        final InputStreamReader rulesReader = new InputStreamReader(new ByteArrayInputStream(rules.getBytes()));
+        final InputStreamReader rulesReader = new InputStreamReader(new ByteArrayInputStream(rules.getBytes(UTF_8)), UTF_8);
 
         final boolean ignoreCase = ConfigUtils.getArg(config, CONF_IGNORE_CASE, DEFAULT_IGNORE_CASE);
 

--- a/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/StandaloneSolrTestSupport.java
+++ b/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/StandaloneSolrTestSupport.java
@@ -1,5 +1,6 @@
 package querqy.solr;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static querqy.solr.QuerqyRewriterRequestHandler.ActionParam.*;
 
 import org.apache.solr.common.util.ContentStreamBase;
@@ -155,7 +156,7 @@ public interface StandaloneSolrTestSupport {
     static String resourceToString(final String resourceName) throws IOException {
         try (final BufferedReader reader = new BufferedReader(new InputStreamReader(
                 Objects.requireNonNull(StandaloneSolrTestSupport.class.getClassLoader()
-                        .getResourceAsStream(resourceName))))) {
+                        .getResourceAsStream(resourceName)), UTF_8))) {
             return reader.lines().collect(Collectors.joining("\n"));
         }
     }

--- a/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/rewriter/replace/ReplaceRewriterFactoryTest.java
+++ b/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/rewriter/replace/ReplaceRewriterFactoryTest.java
@@ -248,33 +248,13 @@ public class ReplaceRewriterFactoryTest extends SolrTestCaseJ4 {
     }
     
     @Test
-    public void testThatNonUtf8EncodedRulesAreParsed() throws NoSuchFieldException, IllegalAccessException {
-        resetCachedDefaultCharsetConstant();
-        
-        String previousFileEncodingSystemPropertyValue = System.getProperty("file.encoding");
-        System.setProperty("file.encoding", "US-ASCII");
-        
-        try {
-            String rules = "veľkostná; veľkostné => velkostna";
-            Map<String, Object> params = Map.of(
-                    CONF_RULES, rules,
-                    CONF_INPUT_DELIMITER, ";"
-            );
-            Assertions.assertThat(factory.validateConfiguration(params)).isNull();
-        } finally {
-            resetCachedDefaultCharsetConstant();
-            if (previousFileEncodingSystemPropertyValue == null) {
-                System.clearProperty("file.encoding");
-            } else {
-                System.setProperty("file.encoding", previousFileEncodingSystemPropertyValue);
-            }
-        }
+    public void testThatNonUtf8EncodedRulesAreParsed() {
+        // issue-346: fails when Strings are parsed with US-ASCII system default
+        String rules = "veľkostná; veľkostné => velkostna";
+        Map<String, Object> params = Map.of(
+                CONF_RULES, rules,
+                CONF_INPUT_DELIMITER, ";"
+        );
+        Assertions.assertThat(factory.validateConfiguration(params)).isNull();
     }
-    
-    private static void resetCachedDefaultCharsetConstant() throws NoSuchFieldException, IllegalAccessException {
-        Field charset = Charset.class.getDeclaredField("defaultCharset");
-        charset.setAccessible(true);
-        charset.set(null, null);
-    }     
-        
 }


### PR DESCRIPTION
* Replaces all occurences of `String.getBytes()` and `new InputStreamReader(InputStream in)` with their charset-specific equivalents.

* A reproducer for buggy behaviour is included in querqy.solr.rewriter.replace.ReplaceRewriterFactoryTest. I did not find a way to re-set the system's cached default charset without using reflection. This produces Java compiler warnings and is likely to break in future JDKs. Maybe we don't want this test here but explicitly set file.encoding for all tests to US-ASCII via the Maven POM?