### PR TITLE
Refactor Instruction interface

### DIFF
--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/CommonRulesRewriter.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/CommonRulesRewriter.java
@@ -108,9 +108,7 @@ public class CommonRulesRewriter extends AbstractNodeVisitor<Node> implements Qu
 
             final Instructions instructions = action.getInstructions();
             instructions.forEach(instruction ->
-                    instruction.apply(sequence, action.getTermMatches(),
-                            action.getStartPosition(),
-                            action.getEndPosition(), expandedQuery, searchEngineRequestAdapter)
+                    instruction.apply(action.getTermMatches(), expandedQuery, searchEngineRequestAdapter)
             );
 
             rewriterLogBuilder.hasAppliedRewriting(true);

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/model/BoostInstruction.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/model/BoostInstruction.java
@@ -72,8 +72,7 @@ public class BoostInstruction implements Instruction {
      *                           java.util.Map)
      */
     @Override
-    public void apply(final PositionSequence<Term> sequence, final TermMatches termMatches,
-                      final int startPosition, final int endPosition, final ExpandedQuery expandedQuery,
+    public void apply(final TermMatches termMatches, final ExpandedQuery expandedQuery,
                       final SearchEngineRequestAdapter searchEngineRequestAdapter) {
 
         if (boost == 0) {

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/model/DecorateInstruction.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/model/DecorateInstruction.java
@@ -54,8 +54,7 @@ public class DecorateInstruction implements Instruction {
      * @see querqy.rewrite.commonrules.model.Instruction#apply(querqy.rewrite.commonrules.model.PositionSequence, querqy.rewrite.commonrules.model.TermMatches, int, int, querqy.model.ExpandedQuery, java.util.Map)
      */
     @Override
-    public void apply(final PositionSequence<Term> sequence, final TermMatches termMatches,
-            final int startPosition, final int endPosition, final ExpandedQuery expandedQuery,
+    public void apply(final TermMatches termMatches, final ExpandedQuery expandedQuery,
                       final SearchEngineRequestAdapter searchEngineRequestAdapter) {
 
         if (this.decorationKey == null) {

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/model/DeleteInstruction.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/model/DeleteInstruction.java
@@ -53,21 +53,15 @@ public class DeleteInstruction implements Instruction {
     * @see querqy.rewrite.commonrules.model.Instruction#apply(querqy.rewrite.commonrules.model.PositionSequence, querqy.rewrite.commonrules.model.TermMatches, int, int, querqy.model.ExpandedQuery, java.util.Map)
     */
    @Override
-   public void apply(final PositionSequence<querqy.model.Term> sequence, final TermMatches termMatches,
-                     final int startPosition, final int endPosition, final ExpandedQuery expandedQuery,
+   public void apply(final TermMatches termMatches, final ExpandedQuery expandedQuery,
                      final SearchEngineRequestAdapter searchEngineRequestAdapter) {
 
-      int pos = 0;
-
-      for (final List<querqy.model.Term> position : sequence) {
-          
-         for (final querqy.model.Term term : position) {
-             if (pos >= startPosition && pos < endPosition && isToBeDeleted(term)) {
-                 term.delete();
-             }
-         }
-         pos++;
-      }
+       for (final TermMatch termMatch : termMatches) {
+           final querqy.model.Term term = termMatch.getQueryTerm();
+           if (isToBeDeleted(term)) {
+               term.delete();
+           }
+       }
    }
 
    public boolean isToBeDeleted(final querqy.model.Term term) {

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/model/FilterInstruction.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/model/FilterInstruction.java
@@ -45,8 +45,7 @@ public class FilterInstruction implements Instruction {
     * * @see querqy.rewrite.commonrules.model.Instruction#apply(querqy.rewrite.commonrules.model.PositionSequence, querqy.rewrite.commonrules.model.TermMatches, int, int, querqy.model.ExpandedQuery, java.util.Map)
     */
     @Override
-    public void apply(final PositionSequence<Term> sequence, final TermMatches termMatches,
-                      final int startPosition, final int endPosition, final ExpandedQuery expandedQuery,
+    public void apply(final TermMatches termMatches, final ExpandedQuery expandedQuery,
                       final SearchEngineRequestAdapter searchEngineRequestAdapter) {
 
         // TODO: we might not need to clone here, if we already cloned all queries in the constructor

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/model/Instruction.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/model/Instruction.java
@@ -22,15 +22,11 @@ public interface Instruction {
     
    /**
     * 
-    * @param sequence The input flattened to a list where one element contains a lists of terms at the given position
     * @param termMatches The terms that match the input condition of the rule
-    * @param startPosition The start position of the match in the sequence
-    * @param endPosition The end position of the match in the sequence
     * @param expandedQuery The query to rewrite
     * @param searchEngineRequestAdapter Access to the request context
     */
-   void apply(PositionSequence<Term> sequence, TermMatches termMatches, int startPosition, int endPosition,
-         ExpandedQuery expandedQuery,  SearchEngineRequestAdapter searchEngineRequestAdapter);
+   void apply(TermMatches termMatches, ExpandedQuery expandedQuery, SearchEngineRequestAdapter searchEngineRequestAdapter);
    
    Set<Term> getGenerableTerms();
 

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/model/SynonymInstruction.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/model/SynonymInstruction.java
@@ -59,8 +59,7 @@ public class SynonymInstruction implements Instruction {
      * @see querqy.rewrite.commonrules.model.Instruction#apply(querqy.rewrite.commonrules.model.PositionSequence, querqy.rewrite.commonrules.model.TermMatches, int, int, querqy.model.ExpandedQuery, java.util.Map)
      */
     @Override
-    public void apply(final PositionSequence<Term> sequence, final TermMatches termMatches,
-                      final int startPosition, final int endPosition, final ExpandedQuery expandedQuery,
+    public void apply(final TermMatches termMatches, final ExpandedQuery expandedQuery,
                       final SearchEngineRequestAdapter searchEngineRequestAdapter) {
         
         switch (termMatches.size()) {

--- a/querqy-core/src/test/java/querqy/rewrite/commonrules/model/RulesCollectionTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/commonrules/model/RulesCollectionTest.java
@@ -383,8 +383,7 @@ public class RulesCollectionTest {
       }
 
       @Override
-      public void apply(PositionSequence<Term> sequence, TermMatches termsMatches, int startPosition, int endPosition,
-                        ExpandedQuery expandedQuery, SearchEngineRequestAdapter searchEngineRequestAdapter) {
+      public void apply(TermMatches termsMatches, ExpandedQuery expandedQuery, SearchEngineRequestAdapter searchEngineRequestAdapter) {
       }
 
     @Override

--- a/querqy-for-lucene/pom.xml
+++ b/querqy-for-lucene/pom.xml
@@ -92,7 +92,7 @@
         <mockito.version>4.9.0</mockito.version>
         <skipITs>true</skipITs>
 
-        <querqy.core.version>3.16.0</querqy.core.version>
+        <querqy.core.version>3.17.0-SNAPSHOT</querqy.core.version>
         <lucene.version>9.0.0</lucene.version>
         <commons.io.version>2.11.0</commons.io.version>
 


### PR DESCRIPTION
I removed three parameters from Instruction interface as they are not needed. It is anyway ensured that DELETE-terms are included in the rule input when parsing the rules. Therefore, deletions can be retrieved from TermMatches.