### PR TITLE
Add a rewriter multiple numerical terms

### DIFF
--- a/querqy-core/src/main/java/querqy/rewrite/contrib/NumberQueryRewriter.java
+++ b/querqy-core/src/main/java/querqy/rewrite/contrib/NumberQueryRewriter.java
@@ -1,0 +1,150 @@
+package querqy.rewrite.contrib;
+
+import querqy.CompoundCharSequence;
+import querqy.model.*;
+import querqy.rewrite.QueryRewriter;
+import querqy.rewrite.RewriterOutput;
+import querqy.rewrite.SearchEngineRequestAdapter;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * <p>A query rewriter that joins two or more adjacent numeric query terms into a new term
+ * and adds this new term to the query as a synonym to the original terms.
+ * A query 01 23 45 thus becomes:</p>
+ * <pre>
+ (01 OR 012345) (23 OR 012345) (45 OR 012345)
+ </pre>
+ *
+ * @author Daniel Wrigley
+ */
+public class NumberQueryRewriter extends AbstractNodeVisitor<Node> implements QueryRewriter {
+
+    Term previousTerm = null;
+    List<Term> termsToAdd = null;
+    List<Term> numberTermsToAdd = new ArrayList<>();
+    int numberOfClauses = 0;
+    int i = 1;
+
+    final boolean acceptGeneratedTerms;
+
+    public NumberQueryRewriter(){
+        this(false);
+    }
+
+    public NumberQueryRewriter(final boolean acceptGeneratedTerms) {
+        this.acceptGeneratedTerms = acceptGeneratedTerms;
+    }
+
+    @Override
+    public RewriterOutput rewrite(final ExpandedQuery query, final SearchEngineRequestAdapter requestAdapter) {
+        final QuerqyQuery<?> userQuery = query.getUserQuery();
+        if (userQuery != null && userQuery instanceof Query){
+            previousTerm = null;
+            termsToAdd = new LinkedList<>();
+            numberOfClauses = ((Query) userQuery).getClauses().size();
+            i = 1;
+            visit((Query) userQuery);
+            for (Term term : termsToAdd) {
+                term.getParent().addClause(term);
+            }
+        }
+        return RewriterOutput.builder().expandedQuery(query).build();
+    }
+
+    @Override
+    public Node visit(final DisjunctionMaxQuery dmq) {
+
+        final List<DisjunctionMaxClause> clauses = dmq.getClauses();
+
+        if (clauses != null) {
+
+            switch (clauses.size()) {
+
+                case 0: break;
+
+                case 1: super.visit(dmq); break;
+
+                default:
+
+                    if (acceptGeneratedTerms) {
+
+                        throw new IllegalArgumentException("cannot handle more than one DMQ clause");
+
+                    } else {
+
+                        DisjunctionMaxClause nonGeneratedClause = null;
+
+                        for (DisjunctionMaxClause clause: clauses) {
+
+                            if (!clause.isGenerated()) {
+                                // second non-generated clause - cannot handle this
+                                if (nonGeneratedClause != null) {
+                                    throw new IllegalArgumentException("cannot handle more than one non-generated DMQ clause");
+                                }
+                                nonGeneratedClause = clause;
+                            }
+                        }
+
+                        if (nonGeneratedClause != null) {
+                            nonGeneratedClause.accept(this);
+                        }
+                    }
+
+            }
+
+
+        }
+
+        return null;
+
+    }
+
+    @Override
+    public Node visit(final Term term) {
+        if (previousTerm != null
+                && eq(previousTerm.getField(), term.getField())
+                && (term.isGenerated() == acceptGeneratedTerms || !term.isGenerated())
+                && (previousTerm.isGenerated() == acceptGeneratedTerms || !previousTerm.isGenerated())) {
+            //if previousTerm and term are digits-only add them to a list
+            if (previousTerm.toString().matches("\\d+") && term.toString().matches("\\d+") && previousTerm.toString().concat(term.toString()).length() > 2) {
+                if (numberTermsToAdd.isEmpty()) {
+                    numberTermsToAdd.add(previousTerm);
+                }
+                numberTermsToAdd.add(term);
+
+                //When switching from digits-only to any other type of term concatenate all collected digit-only terms
+            } else if (!numberTermsToAdd.isEmpty()) {
+                processTerms(numberTermsToAdd);
+            }
+            //When we are looking at the last term (i==numberOfClauses) and we have something to process (!numberTermsToAdd.isEmpty())
+            //we process the numeric terms. Otherwise we wouldn't do anything with numeric terms at the end of a query.
+            if (i==numberOfClauses && !numberTermsToAdd.isEmpty()) {
+                processTerms(numberTermsToAdd);
+            }
+        }
+        previousTerm = term;
+        i++;
+        return term;
+    }
+
+    private void processTerms(List<Term> numberTermsToAdd) {
+        final CharSequence seq = new CompoundCharSequence(null, numberTermsToAdd);
+        for (Term numberTerm : numberTermsToAdd) {
+            termsToAdd.add(new Term(numberTerm.getParent(), numberTerm.getField(), seq, true));
+        }
+        numberTermsToAdd.clear();
+    }
+
+    private static <T> boolean eq(final T value1, final T value2) {
+        return value1 == null && value2 == null || value1 != null && value1.equals(value2);
+    }
+
+    @Override
+    public Node visit(final BooleanQuery bq) {
+        previousTerm = null;
+        return super.visit(bq);
+    }
+}

--- a/querqy-core/src/main/java/querqy/rewrite/contrib/NumberQueryRewriterFactory.java
+++ b/querqy-core/src/main/java/querqy/rewrite/contrib/NumberQueryRewriterFactory.java
@@ -14,6 +14,7 @@ import java.util.Set;
 public class NumberQueryRewriterFactory extends RewriterFactory {
 
     protected final boolean acceptGeneratedTerms;
+    protected int minimumLengthOfResultingQueryTerm;
 
     public NumberQueryRewriterFactory(final String rewriterId) {
 
@@ -21,13 +22,18 @@ public class NumberQueryRewriterFactory extends RewriterFactory {
     }
 
     public NumberQueryRewriterFactory(final String rewriterId, final boolean acceptGeneratedTerms) {
+        this(rewriterId, acceptGeneratedTerms, 3);
+    }
+
+    public NumberQueryRewriterFactory(final String rewriterId, final boolean acceptGeneratedTerms, final int minimumLengthOfResultingQueryTerm) {
         super(rewriterId);
         this.acceptGeneratedTerms = acceptGeneratedTerms;
+        this.minimumLengthOfResultingQueryTerm = minimumLengthOfResultingQueryTerm;
     }
 
     @Override
-    public QueryRewriter createRewriter(ExpandedQuery input, SearchEngineRequestAdapter searchEngineRequestAdapter) {
-        return new NumberQueryRewriter(acceptGeneratedTerms);
+    public QueryRewriter createRewriter(final ExpandedQuery input, final SearchEngineRequestAdapter searchEngineRequestAdapter) {
+        return new NumberQueryRewriter(acceptGeneratedTerms, minimumLengthOfResultingQueryTerm);
     }
 
     @Override

--- a/querqy-core/src/main/java/querqy/rewrite/contrib/NumberQueryRewriterFactory.java
+++ b/querqy-core/src/main/java/querqy/rewrite/contrib/NumberQueryRewriterFactory.java
@@ -1,0 +1,41 @@
+package querqy.rewrite.contrib;
+
+import querqy.model.ExpandedQuery;
+import querqy.model.Term;
+import querqy.rewrite.QueryRewriter;
+import querqy.rewrite.RewriterFactory;
+import querqy.rewrite.SearchEngineRequestAdapter;
+
+import java.util.Set;
+
+/**
+ * Factory for {@link NumberQueryRewriter}
+ */
+public class NumberQueryRewriterFactory extends RewriterFactory {
+
+    protected final boolean acceptGeneratedTerms;
+
+    public NumberQueryRewriterFactory(final String rewriterId) {
+
+        this(rewriterId, false);
+    }
+
+    public NumberQueryRewriterFactory(final String rewriterId, final boolean acceptGeneratedTerms) {
+        super(rewriterId);
+        this.acceptGeneratedTerms = acceptGeneratedTerms;
+    }
+
+    @Override
+    public QueryRewriter createRewriter(ExpandedQuery input, SearchEngineRequestAdapter searchEngineRequestAdapter) {
+        return new NumberQueryRewriter(acceptGeneratedTerms);
+    }
+
+    @Override
+    public Set<Term> getCacheableGenerableTerms() {
+        return QueryRewriter.EMPTY_GENERABLE_TERMS;
+    }
+
+    public boolean isAcceptGeneratedTerms() {
+        return acceptGeneratedTerms;
+    }
+}

--- a/querqy-core/src/test/java/querqy/rewrite/contrib/NumberQueryRewriterTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/contrib/NumberQueryRewriterTest.java
@@ -1,0 +1,2 @@
+package querqy.rewrite.contrib;public class NumberQueryRewriterTest {
+}

--- a/querqy-core/src/test/java/querqy/rewrite/contrib/NumberQueryRewriterTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/contrib/NumberQueryRewriterTest.java
@@ -1,2 +1,226 @@
-package querqy.rewrite.contrib;public class NumberQueryRewriterTest {
+package querqy.rewrite.contrib;
+
+import org.junit.Test;
+
+import querqy.model.Clause;
+import querqy.model.DisjunctionMaxQuery;
+import querqy.model.ExpandedQuery;
+import querqy.model.Query;
+import querqy.model.Term;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static querqy.QuerqyMatchers.bq;
+import static querqy.QuerqyMatchers.dmq;
+import static querqy.QuerqyMatchers.term;
+
+public class NumberQueryRewriterTest {
+
+    @Test
+    public void testNumberConcatenationForTwoTokens() {
+        Query query = new Query();
+        addTerm(query, "123");
+        addTerm(query, "456");
+        ExpandedQuery expandedQuery = new ExpandedQuery(query);
+        NumberQueryRewriter rewriter = new NumberQueryRewriter();
+        rewriter.rewrite(expandedQuery, null);
+
+        assertThat((Query) expandedQuery.getUserQuery(),
+                bq(
+                        dmq(
+                                term("123"),
+                                term("123456")
+                        ),
+                        dmq(
+                                term("456"),
+                                term("123456")
+                        )
+                )
+        );
+    }
+
+    @Test
+    public void testNumberConcatenationForMultipleTokens() {
+        Query query = new Query();
+        addTerm(query, "a");
+        addTerm(query, "123");
+        addTerm(query, "456");
+        addTerm(query, "789");
+        addTerm(query, "b");
+        ExpandedQuery expandedQuery = new ExpandedQuery(query);
+        NumberQueryRewriter rewriter = new NumberQueryRewriter();
+        rewriter.rewrite(expandedQuery, null);
+
+        assertThat((Query) expandedQuery.getUserQuery(),
+                bq(
+                        dmq(
+                                term("a")
+                        ),
+                        dmq(
+                                term("123"),
+                                term("123456789")
+                        ),
+                        dmq(
+                                term("456"),
+                                term("123456789")
+                        ),
+                        dmq(
+                                term("789"),
+                                term("123456789")
+                        ),
+                        dmq(
+                                term("b")
+                        )
+                )
+        );
+    }
+
+    @Test
+    public void testSingleNumericTokenIsPreserved() {
+        Query query = new Query();
+        addTerm(query, "1");
+        ExpandedQuery expandedQuery = new ExpandedQuery(query);
+        NumberQueryRewriter rewriter = new NumberQueryRewriter();
+        rewriter.rewrite(expandedQuery, null);
+
+        assertThat((Query) expandedQuery.getUserQuery(),
+                bq(
+                        dmq(
+                                term("1")
+                        )
+                )
+        );
+    }
+
+    @Test
+    public void testNumberConcatenationWithinSameField() {
+        Query query = new Query();
+        addTerm(query, "f1", "123");
+        addTerm(query, "f1", "456");
+        ExpandedQuery expandedQuery = new ExpandedQuery(query);
+        NumberQueryRewriter rewriter = new NumberQueryRewriter();
+        rewriter.rewrite(expandedQuery, null);
+
+        assertThat((Query) expandedQuery.getUserQuery(),
+                bq(
+                        dmq(
+                                term("f1", "123"),
+                                term("f1", "123456")
+                        ),
+                        dmq(
+                                term("f1", "456"),
+                                term("f1", "123456")
+                        )
+                )
+        );
+    }
+
+    @Test
+    public void testNoNumberConcatenationForDifferentFields() {
+        Query query = new Query();
+        addTerm(query, "f1", "123");
+        addTerm(query, "f2", "456");
+        ExpandedQuery expandedQuery = new ExpandedQuery(query);
+        NumberQueryRewriter rewriter = new NumberQueryRewriter();
+        rewriter.rewrite(expandedQuery, null);
+
+        assertThat((Query) expandedQuery.getUserQuery(),
+                bq(
+                        dmq(
+                                term("f1", "123")
+                        ),
+                        dmq(
+                                term("f2", "456")
+                        )
+                )
+        );
+    }
+
+    @Test
+    public void testNoNumberConcatenationForFieldAndAllFieldsQuery() {
+        Query query = new Query();
+        addTerm(query, "123");
+        addTerm(query, "f", "456");
+        ExpandedQuery expandedQuery = new ExpandedQuery(query);
+        NumberQueryRewriter rewriter = new NumberQueryRewriter();
+        rewriter.rewrite(expandedQuery, null);
+
+        assertThat((Query) expandedQuery.getUserQuery(),
+                bq(
+                        dmq(
+                                term(null, "123")
+                        ),
+                        dmq(
+                                term("f", "456")
+                        )
+                )
+        );
+    }
+
+    @Test
+    public void testNoNumberConcatenationForGeneratedTerms() {
+        Query query = new Query();
+        addTerm(query, "123");
+        addTerm(query, "456", true);
+        ExpandedQuery expandedQuery = new ExpandedQuery(query);
+        NumberQueryRewriter rewriter = new NumberQueryRewriter();
+        rewriter.rewrite(expandedQuery, null);
+
+        assertThat((Query) expandedQuery.getUserQuery(),
+                bq(
+                        dmq(
+                                term(null, "123")
+                        ),
+                        dmq(
+                                term(null, "456")
+                        )
+                )
+        );
+    }
+
+    @Test
+    public void testNumberConcatenationForGeneratedTermsIfConfigured() {
+        Query query = new Query();
+        addTerm(query, "123");
+        addTerm(query, "456", true);
+        ExpandedQuery expandedQuery = new ExpandedQuery(query);
+        NumberQueryRewriter rewriter = new NumberQueryRewriter(true, 3);
+        rewriter.rewrite(expandedQuery, null);
+
+        assertThat((Query) expandedQuery.getUserQuery(),
+                bq(
+                        dmq(
+                                term(null, "123"),
+                                term(null, "123456")
+                        ),
+                        dmq(
+                                term(null, "456"),
+                                term(null, "123456")
+                        )
+                )
+        );
+    }
+
+    private void addTerm(Query query, String value) {
+        addTerm(query, null, value);
+    }
+
+    private void addTerm(Query query, String field, String value) {
+        DisjunctionMaxQuery dmq = new DisjunctionMaxQuery(query, Clause.Occur.SHOULD, true);
+        query.addClause(dmq);
+        Term term = new Term(dmq, field, value);
+        dmq.addClause(term);
+    }
+
+    private void addTerm(Query query, String value, boolean isGenerated) {
+        addTerm(query, null, value, isGenerated);
+    }
+
+    private void addTerm(Query query, String field, String value, boolean isGenerated) {
+        DisjunctionMaxQuery dmq = new DisjunctionMaxQuery(query, Clause.Occur.SHOULD, true);
+        query.addClause(dmq);
+        Term term = new Term(dmq, field, value, isGenerated);
+        dmq.addClause(term);
+    }
+
+
 }

--- a/querqy-for-lucene/pom.xml
+++ b/querqy-for-lucene/pom.xml
@@ -75,7 +75,7 @@
         <mockito.version>5.11.0</mockito.version>
         <skipITs>true</skipITs>
 
-        <querqy.core.version>3.17.0</querqy.core.version>
+        <querqy.core.version>3.18.0-SNAPSHOT</querqy.core.version>
         <lucene.version>9.8.0</lucene.version>
         <commons.io.version>2.14.0</commons.io.version>
 

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/rewriter/NumberQueryRewriterFactory.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/rewriter/NumberQueryRewriterFactory.java
@@ -6,7 +6,7 @@ import querqy.solr.RewriterConfigRequestBuilder;
 import querqy.solr.SolrRewriterFactoryAdapter;
 import querqy.solr.utils.ConfigUtils;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,8 +17,11 @@ import java.util.Map;
 public class NumberQueryRewriterFactory extends SolrRewriterFactoryAdapter implements ClassicConfigurationParser {
 
     public static final String CONF_ACCEPT_GENERATED_TERMS = "acceptGeneratedTerms";
+    public static final String CONF_MIN_LENGTH_QUERY_TERM = "minimumLengthOfResultingQueryTerm";
 
-    querqy.rewrite.contrib.NumberQueryRewriterFactory factory = null;
+    public static  final int DEFAULT_MIN_LENGTH_QUERY_TERM = 3;
+
+    private querqy.rewrite.contrib.NumberQueryRewriterFactory factory = null;
 
     public NumberQueryRewriterFactory(final String rewriterId) {
         super(rewriterId);
@@ -26,23 +29,34 @@ public class NumberQueryRewriterFactory extends SolrRewriterFactoryAdapter imple
 
     @Override
     public void configure(final Map<String, Object> config) throws SolrException {
+        final boolean accept = ConfigUtils.getArg(config, CONF_ACCEPT_GENERATED_TERMS, Boolean.FALSE);
 
-        factory = ConfigUtils.getBoolArg(config, CONF_ACCEPT_GENERATED_TERMS)
-                .map(accept -> new querqy.rewrite.contrib.NumberQueryRewriterFactory(rewriterId, accept))
-                .orElseGet(() -> new querqy.rewrite.contrib.NumberQueryRewriterFactory(rewriterId));
+        // the maximum length of a combined term
+        final Integer minimumLength = ConfigUtils.getArg(config, CONF_MIN_LENGTH_QUERY_TERM,
+                DEFAULT_MIN_LENGTH_QUERY_TERM);
 
+        factory = new querqy.rewrite.contrib.NumberQueryRewriterFactory(rewriterId, accept, minimumLength);
     }
 
     @Override
     public List<String> validateConfiguration(final Map<String, Object> config) {
+        List<String> errors = new ArrayList<>();
+
         try {
             ConfigUtils.getBoolArg(config, CONF_ACCEPT_GENERATED_TERMS);
-            return null;
-        } catch (final Exception e){
-            return Collections.singletonList("boolean value expected for " + CONF_ACCEPT_GENERATED_TERMS);
+        } catch (final Exception e) {
+            errors.add("boolean value expected for " + CONF_ACCEPT_GENERATED_TERMS);
         }
 
+        try {
+            ConfigUtils.getIntArg(config, CONF_MIN_LENGTH_QUERY_TERM);
+        } catch (final Exception e) {
+            errors.add("integer value expected for " + CONF_MIN_LENGTH_QUERY_TERM);
+        }
+
+        return errors.isEmpty() ? null : errors;
     }
+
 
     @Override
     public RewriterFactory getRewriterFactory() {
@@ -52,29 +66,31 @@ public class NumberQueryRewriterFactory extends SolrRewriterFactoryAdapter imple
     public static class NumberQueryConfigRequestBuilder extends RewriterConfigRequestBuilder {
 
         private Boolean acceptGeneratedTerms;
+        private Integer minimumLengthOfResultingQueryTerm;
 
         public NumberQueryConfigRequestBuilder() {
             super(NumberQueryRewriterFactory.class);
         }
 
-        public NumberQueryConfigRequestBuilder(final boolean acceptGeneratedTerms) {
-            super(NumberQueryRewriterFactory.class);
-            this.acceptGeneratedTerms = acceptGeneratedTerms;
-        }
-
         @Override
         public Map<String, Object> buildConfig() {
-            if (acceptGeneratedTerms == null) {
-                return Collections.emptyMap();
-            } else {
-                final Map<String, Object> config = new HashMap<>(1);
+            final Map<String, Object> config = new HashMap<>();
+            if (acceptGeneratedTerms != null) {
                 config.put(CONF_ACCEPT_GENERATED_TERMS, acceptGeneratedTerms);
-                return config;
             }
+            if (minimumLengthOfResultingQueryTerm != null) {
+                config.put(CONF_MIN_LENGTH_QUERY_TERM, minimumLengthOfResultingQueryTerm);
+            }
+            return config;
         }
 
         public NumberQueryConfigRequestBuilder acceptGeneratedTerms(final Boolean accept) {
             acceptGeneratedTerms = accept;
+            return this;
+        }
+
+        public NumberQueryConfigRequestBuilder minimumLengthOfResultingQueryTerm(final Integer minimumLength) {
+            minimumLengthOfResultingQueryTerm = minimumLength;
             return this;
         }
 

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/rewriter/NumberQueryRewriterFactory.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/rewriter/NumberQueryRewriterFactory.java
@@ -1,0 +1,82 @@
+package querqy.solr.rewriter;
+
+import org.apache.solr.common.SolrException;
+import querqy.rewrite.RewriterFactory;
+import querqy.solr.RewriterConfigRequestBuilder;
+import querqy.solr.SolrRewriterFactoryAdapter;
+import querqy.solr.utils.ConfigUtils;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * RewriterFactoryLoader for {@link NumberQueryRewriterFactory}
+ */
+public class NumberQueryRewriterFactory extends SolrRewriterFactoryAdapter implements ClassicConfigurationParser {
+
+    public static final String CONF_ACCEPT_GENERATED_TERMS = "acceptGeneratedTerms";
+
+    querqy.rewrite.contrib.NumberQueryRewriterFactory factory = null;
+
+    public NumberQueryRewriterFactory(final String rewriterId) {
+        super(rewriterId);
+    }
+
+    @Override
+    public void configure(final Map<String, Object> config) throws SolrException {
+
+        factory = ConfigUtils.getBoolArg(config, CONF_ACCEPT_GENERATED_TERMS)
+                .map(accept -> new querqy.rewrite.contrib.NumberQueryRewriterFactory(rewriterId, accept))
+                .orElseGet(() -> new querqy.rewrite.contrib.NumberQueryRewriterFactory(rewriterId));
+
+    }
+
+    @Override
+    public List<String> validateConfiguration(final Map<String, Object> config) {
+        try {
+            ConfigUtils.getBoolArg(config, CONF_ACCEPT_GENERATED_TERMS);
+            return null;
+        } catch (final Exception e){
+            return Collections.singletonList("boolean value expected for " + CONF_ACCEPT_GENERATED_TERMS);
+        }
+
+    }
+
+    @Override
+    public RewriterFactory getRewriterFactory() {
+        return factory;
+    }
+
+    public static class NumberQueryConfigRequestBuilder extends RewriterConfigRequestBuilder {
+
+        private Boolean acceptGeneratedTerms;
+
+        public NumberQueryConfigRequestBuilder() {
+            super(NumberQueryRewriterFactory.class);
+        }
+
+        public NumberQueryConfigRequestBuilder(final boolean acceptGeneratedTerms) {
+            super(NumberQueryRewriterFactory.class);
+            this.acceptGeneratedTerms = acceptGeneratedTerms;
+        }
+
+        @Override
+        public Map<String, Object> buildConfig() {
+            if (acceptGeneratedTerms == null) {
+                return Collections.emptyMap();
+            } else {
+                final Map<String, Object> config = new HashMap<>(1);
+                config.put(CONF_ACCEPT_GENERATED_TERMS, acceptGeneratedTerms);
+                return config;
+            }
+        }
+
+        public NumberQueryConfigRequestBuilder acceptGeneratedTerms(final Boolean accept) {
+            acceptGeneratedTerms = accept;
+            return this;
+        }
+
+    }
+}

--- a/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/utils/ConfigUtils.java
+++ b/querqy-for-lucene/querqy-solr/src/main/java/querqy/solr/utils/ConfigUtils.java
@@ -14,6 +14,17 @@ public interface ConfigUtils {
         return value == null ? defaultValue : value;
     }
 
+    static Optional<Integer> getIntArg(final Map<String, Object> config, final String name) {
+        final Object object = config.get(name);
+        if (object == null) {
+            return Optional.empty();
+        } else if (object instanceof Integer) {
+            return Optional.of((Integer) object);
+        } else {
+            return Optional.of(Integer.parseInt(object.toString()));
+        }
+    }
+
     static Optional<String> getStringArg(final Map<String, Object> config, final String name) {
         return Optional.ofNullable((String) config.get(name));
     }

--- a/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/rewriter/NumberQueryRewriterFactoryTest.java
+++ b/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/rewriter/NumberQueryRewriterFactoryTest.java
@@ -1,0 +1,38 @@
+package querqy.solr.rewriter;
+
+import org.apache.solr.common.util.NamedList;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import querqy.lucene.GZIPAwareResourceLoader;
+import querqy.rewrite.RewriterFactory;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static querqy.solr.RewriterConfigRequestBuilder.CONF_CLASS;
+import static querqy.solr.RewriterConfigRequestBuilder.CONF_CONFIG;
+import static querqy.solr.rewriter.NumberQueryRewriterFactory.CONF_ACCEPT_GENERATED_TERMS;
+
+public class NumberQueryRewriterFactoryTest {
+
+    private final NumberQueryRewriterFactory factory = new NumberQueryRewriterFactory("test");
+
+    @Test
+    public void testThatDeprecatedConfigurationIsCorrectlyParsed() {
+
+        final GZIPAwareResourceLoader resourceLoader = mock(GZIPAwareResourceLoader.class);
+
+        NamedList<Object> configuration = new NamedList<>();
+        configuration.add(CONF_CLASS, NumberQueryRewriterFactory.class.getName());
+        configuration.add(CONF_ACCEPT_GENERATED_TERMS, true);
+
+        Map<String, Object> parsed = factory.parseConfigurationToRequestHandlerBody(configuration, resourceLoader);
+        // no exceptions!
+        factory.configure((Map<String, Object>) parsed.get(CONF_CONFIG));
+
+        RewriterFactory rewriterFactory = factory.getRewriterFactory();
+
+        Assertions.assertThat(rewriterFactory).isInstanceOf(querqy.rewrite.contrib.NumberQueryRewriterFactory.class);
+        Assertions.assertThat(factory.validateConfiguration((Map<String, Object>) parsed.get(CONF_CONFIG))).isNullOrEmpty();
+    }
+}

--- a/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/rewriter/NumberQueryRewriterTest.java
+++ b/querqy-for-lucene/querqy-solr/src/test/java/querqy/solr/rewriter/NumberQueryRewriterTest.java
@@ -1,0 +1,239 @@
+package querqy.solr.rewriter;
+
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.params.DisMaxParams;
+import org.apache.solr.request.SolrQueryRequest;
+import org.hamcrest.collection.IsMapContaining;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static querqy.solr.QuerqyQParserPlugin.PARAM_REWRITERS;
+import static querqy.solr.StandaloneSolrTestSupport.withCommonRulesRewriter;
+import static querqy.solr.StandaloneSolrTestSupport.withRewriter;
+
+@SolrTestCaseJ4.SuppressSSL
+public class NumberQueryRewriterTest extends SolrTestCaseJ4 {
+
+    private final static String REWRITERS = "common_rules_before_shingles,shingles,common_rules_after_shingles";
+
+    @BeforeClass
+    public static void beforeTests() throws Exception {
+        initCore("solrconfig.xml", "schema.xml");
+        withCommonRulesRewriter(h.getCore(), "common_rules_before_shingles",
+                "configs/commonrules/rules-before-shingles.txt");
+        final Map<String, Object> config = new HashMap<>();
+        config.put("acceptGeneratedTerms", false);
+        withRewriter(h.getCore(), "shingles", NumberQueryRewriterFactory.class, config);
+        withCommonRulesRewriter(h.getCore(), "common_rules_after_shingles",
+                "configs/commonrules/rules-shingles.txt");
+    }
+
+    @Test
+    public void testOnTwoNumberTerms() {
+        String q = "01 23 c";
+
+        SolrQueryRequest req = req("q", q,
+                DisMaxParams.QF, "f1 f2 f3",
+                "defType", "querqy",
+                "debugQuery", "on",
+                PARAM_REWRITERS, REWRITERS
+        );
+
+        assertQ("Missing shingles",
+                req,
+                "//str[@name='parsedquery'][contains(.,'0123')]",
+                "//str[@name='parsedquery'][not(contains(.,'23c'))]"
+
+        );
+
+        req.close();
+    }
+
+    @Test
+    public void testOnShortNumberTerms() {
+        String q = "1 23 c";
+
+        SolrQueryRequest req = req("q", q,
+                DisMaxParams.QF, "f1 f2 f3",
+                "defType", "querqy",
+                "debugQuery", "on",
+                PARAM_REWRITERS, REWRITERS
+        );
+
+        assertQ("Missing shingles",
+                req,
+                "//str[@name='parsedquery'][contains(.,'123')]",
+                "//str[@name='parsedquery'][not(contains(.,'23c'))]"
+
+        );
+
+        req.close();
+    }
+
+    @Test
+    public void testOnTooShortNumberTerms() {
+        String q = "1 2 c";
+
+        SolrQueryRequest req = req("q", q,
+                DisMaxParams.QF, "f1 f2 f3",
+                "defType", "querqy",
+                "debugQuery", "on",
+                PARAM_REWRITERS, REWRITERS
+        );
+
+        assertQ("Missing shingles",
+                req,
+                "//str[@name='parsedquery'][not(contains(.,'12'))]",
+                "//str[@name='parsedquery'][not(contains(.,'2c'))]"
+
+        );
+
+        req.close();
+    }
+
+    @Test
+    public void testOnMultipleNumberTerms() {
+        String q = "01 23 c 45 67";
+
+        SolrQueryRequest req = req("q", q,
+                DisMaxParams.QF, "f1 f2 f3",
+                "defType", "querqy",
+                "debugQuery", "on",
+                PARAM_REWRITERS, REWRITERS
+        );
+
+        assertQ("Missing shingles",
+                req,
+                "//str[@name='parsedquery'][contains(.,'0123')]",
+                "//str[@name='parsedquery'][contains(.,'4567')]"
+
+        );
+
+        req.close();
+    }
+
+    @Test
+    public void testOnNumberTermsOnly() {
+        String q = "01 23 45 67";
+
+        SolrQueryRequest req = req("q", q,
+                DisMaxParams.QF, "f1 f2 f3",
+                "defType", "querqy",
+                "debugQuery", "on",
+                PARAM_REWRITERS, REWRITERS
+        );
+
+        assertQ("Wrong shingles",
+                req,
+                "//str[@name='parsedquery'][contains(.,'01234567')]",
+                "//str[@name='parsedquery'][not(contains(.,':4567'))]"
+
+        );
+
+        req.close();
+    }
+    @Test
+    public void testNumberAndSpecialCharCombination() {
+        String q = "01.23 45 67";
+
+        SolrQueryRequest req = req("q", q,
+                DisMaxParams.QF, "f1 f2 f3",
+                "defType", "querqy",
+                "debugQuery", "on",
+                PARAM_REWRITERS, REWRITERS
+        );
+
+        assertQ("Wrong shingles",
+                req,
+                "//str[@name='parsedquery'][contains(.,'4567')]",
+                "//str[@name='parsedquery'][not(contains(.,'0123'))]"
+
+        );
+
+        req.close();
+    }
+
+    @Test
+    public void testThatNumberShinglesAreNotCreatedOnWordOrGeneratedTerms() {
+        String q = "t1 t2";
+
+        SolrQueryRequest req = req("q", q,
+                DisMaxParams.QF, "f1",
+                "defType", "querqy",
+                "debugQuery", "on",
+                PARAM_REWRITERS, REWRITERS
+        );
+
+        assertQ("Problem with shingles on generated terms",
+                req,
+                "//str[@name='parsedquery'][not(contains(.,'t1t2'))]",
+                "//str[@name='parsedquery'][not(contains(.,'s1t2'))]"
+
+        );
+
+        req.close();
+    }
+
+    @Test
+    public void testConfigRequestAcceptGeneratedTerms() {
+        final Map<String, Object> config = new NumberQueryRewriterFactory.NumberQueryConfigRequestBuilder()
+                .acceptGeneratedTerms(true).buildConfig();
+
+        org.hamcrest.MatcherAssert.assertThat(config, IsMapContaining.hasEntry(
+                NumberQueryRewriterFactory.CONF_ACCEPT_GENERATED_TERMS, Boolean.TRUE));
+
+        final NumberQueryRewriterFactory factory = new NumberQueryRewriterFactory("id");
+
+        final List<String> errors = factory.validateConfiguration(config);
+        assertTrue(errors == null || errors.isEmpty());
+
+        // TODO: read the acceptGeneratedTerms property once it becomes accessible
+
+        // make sure that no exception  is thrown
+        factory.configure(config);
+
+    }
+
+    @Test
+    public void testConfigRequestDoNotAcceptGeneratedTerms() {
+        final Map<String, Object> config = new NumberQueryRewriterFactory.NumberQueryConfigRequestBuilder()
+                .acceptGeneratedTerms(false).buildConfig();
+
+        org.hamcrest.MatcherAssert.assertThat(config, IsMapContaining.hasEntry(
+                ShingleRewriterFactory.CONF_ACCEPT_GENERATED_TERMS, Boolean.FALSE));
+
+        final NumberQueryRewriterFactory factory = new NumberQueryRewriterFactory("id");
+
+        final List<String> errors = factory.validateConfiguration(config);
+        assertTrue(errors == null || errors.isEmpty());
+
+        // TODO: read the acceptGeneratedTerms property once it becomes accessible
+
+        // make sure that no exception  is thrown
+        factory.configure(config);
+
+    }
+
+    @Test
+    public void testConfigRequestDefaultAcceptGeneratedTerms() {
+        final Map<String, Object> config = new NumberQueryRewriterFactory.NumberQueryConfigRequestBuilder().buildConfig();
+
+        assertTrue(config.isEmpty());
+
+        final NumberQueryRewriterFactory factory = new NumberQueryRewriterFactory("id");
+
+        final List<String> errors = factory.validateConfiguration(config);
+        assertTrue(errors == null || errors.isEmpty());
+
+        // TODO: read the acceptGeneratedTerms property once it becomes accessible
+
+        // make sure that no exception  is thrown
+        factory.configure(config);
+
+    }
+
+}


### PR DESCRIPTION
(by external expert on behalf of DB Systel GmbH)

Add a rewriter for handling queries with multiple numerical terms.

Co-authored-by: Kristina Braun Kristina.Braun@deutschebahn.com
Co-authored-by: Matthias Krueger Matthias.M.Krueger-extern@deutschebahn.com

Reviewed-by: Kristina.Braun@deutschebahn.com