### PR TITLE
Compatiblity to lucene 9.11 and solr 9.6

### DIFF
--- a/querqy-core/pom.xml
+++ b/querqy-core/pom.xml
@@ -65,7 +65,7 @@
         <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
-        <lombok.version>1.18.28</lombok.version>
+        <lombok.version>1.18.30</lombok.version>
         <junit.version>4.13.2</junit.version>
         <hamcrest.version>2.2</hamcrest.version>
         <mockito.version>5.11.0</mockito.version>

--- a/querqy-for-lucene/pom.xml
+++ b/querqy-for-lucene/pom.xml
@@ -75,8 +75,8 @@
         <mockito.version>5.11.0</mockito.version>
         <skipITs>true</skipITs>
 
-        <querqy.core.version>3.17.0</querqy.core.version>
-        <lucene.version>9.8.0</lucene.version>
+        <querqy.core.version>3.18.0-SNAPSHOT</querqy.core.version>
+        <lucene.version>9.11.1</lucene.version>
         <commons.io.version>2.14.0</commons.io.version>
 
     </properties>
@@ -128,7 +128,7 @@
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <systemPropertyVariables>
-                        <tests.codec>Lucene95</tests.codec>
+                        <tests.codec>Lucene99</tests.codec>
                         <java.security.egd>file:/dev/./urandom</java.security.egd>
                         <!-- Use narrow US-ASCII as default Java character set (via file.encoding system property)
                         to increase the chance of catching code that relies on the JDK default encoding -->

--- a/querqy-for-lucene/pom.xml
+++ b/querqy-for-lucene/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.querqy</groupId>
     <artifactId>querqy-for-lucene</artifactId>
-    <version>5.8.lucene942.0-SNAPSHOT</version>
+    <version>5.8.lucene9110.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/querqy-for-lucene/querqy-lucene/pom.xml
+++ b/querqy-for-lucene/querqy-lucene/pom.xml
@@ -5,7 +5,7 @@
         <groupId>org.querqy</groupId>
         <artifactId>querqy-for-lucene</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>5.8.lucene942.0-SNAPSHOT</version>
+        <version>5.8.lucene9110.0-SNAPSHOT</version>
     </parent>
     <artifactId>querqy-lucene</artifactId>
 

--- a/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/rewrite/FieldBoostTermQueryBuilder.java
+++ b/querqy-for-lucene/querqy-lucene/src/main/java/querqy/lucene/rewrite/FieldBoostTermQueryBuilder.java
@@ -1,6 +1,5 @@
 package querqy.lucene.rewrite;
 
-import org.apache.lucene.index.IndexReaderContext;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.PostingsEnum;
@@ -19,7 +18,6 @@ import org.apache.lucene.search.Weight;
 
 import java.io.IOException;
 import java.util.Optional;
-import java.util.Set;
 
 public class FieldBoostTermQueryBuilder implements TermQueryBuilder {
 
@@ -61,8 +59,8 @@ public class FieldBoostTermQueryBuilder implements TermQueryBuilder {
         @Override
         public Weight createWeight(final IndexSearcher searcher, final ScoreMode scoreMode, final float boost)
                 throws IOException {
-            final IndexReaderContext context = searcher.getTopReaderContext();
-            final TermStates termState = TermStates.build(context, term, scoreMode.needsScores());
+
+            final TermStates termState = TermStates.build(searcher, term, scoreMode.needsScores());
             // TODO: set boosts to 1f if needsScores is false?
             return new FieldBoostWeight(termState, boost, fieldBoost.getBoost(term.field(), searcher.getIndexReader()));
         }

--- a/querqy-for-lucene/querqy-solr/pom.xml
+++ b/querqy-for-lucene/querqy-solr/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.querqy</groupId>
         <artifactId>querqy-for-lucene</artifactId>
-        <version>5.8.lucene942.0-SNAPSHOT</version>
+        <version>5.8.lucene9110.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -195,7 +195,7 @@
                         <project.build.directory>${project.build.directory}</project.build.directory>
                         <project.build.finalName>${project.build.finalName}</project.build.finalName>
                         <project.version>${project.version}</project.version>
-                        <solr.test.versions>solr:9.4,solr:9.3,solr:9.2,solr:9.1,solr:9.0</solr.test.versions>
+                        <solr.test.versions>solr:9.6,solr:9.5,solr:9.4,solr:9.3,solr:9.2,solr:9.1,solr:9.0</solr.test.versions>
                     </systemPropertyVariables>
                 </configuration>
                 <executions>

--- a/querqy-for-lucene/querqy-solr/pom.xml
+++ b/querqy-for-lucene/querqy-solr/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <minidev.json-smart.version>2.4.10</minidev.json-smart.version>
         <slf4j.version>2.0.7</slf4j.version>
-        <solr.version>9.4.0</solr.version>
+        <solr.version>9.6.1</solr.version>
         <testcontainers.version>1.19.7</testcontainers.version>
     </properties>
 


### PR DESCRIPTION
This PR bumps Lucene and Solr to most recent versions. Intention is to build [Querqy for Elasticsearch](https://github.com/querqy/querqy-elasticsearch) for Elasticsearch v8.15.0. For being able to do this `querqy.lucene.rewrite.FieldBoostTermQueryBuilder::createWeight` method needed to get fixed. 

I am not very much into Java and have no clue what I am doing tbh. So I am happy for any advice and support. Thanks in advance.