### PR TITLE
Lucene 10.4 bump for Querqy

### DIFF
--- a/querqy-lucene/pom.xml
+++ b/querqy-lucene/pom.xml
@@ -56,7 +56,7 @@
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
 
         <querqy.core.version>3.20.2</querqy.core.version>
-        <lucene.version>10.3.2</lucene.version>
+        <lucene.version>10.4.0</lucene.version>
         <junit.version>4.13.2</junit.version>
         <hamcrest.version>3.0</hamcrest.version>
         <mockito.version>5.23.0</mockito.version>

--- a/querqy-lucene/pom.xml
+++ b/querqy-lucene/pom.xml
@@ -147,7 +147,7 @@
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <systemPropertyVariables>
-                        <tests.codec>Lucene103</tests.codec>
+                        <tests.codec>Lucene104</tests.codec>
                         <java.security.egd>file:/dev/./urandom</java.security.egd>
                         <!-- Use narrow US-ASCII as default Java character set (via file.encoding system property)
                         to increase the chance of catching code that relies on the JDK default encoding -->


### PR DESCRIPTION
This fixes #1107 and incorporates the dependabot work in https://github.com/querqy/querqy/pull/1106/commits.