### PR TITLE
Remove json-smart transitive dependency from querqy-core. Closes #1114

### DIFF
--- a/querqy-core/pom.xml
+++ b/querqy-core/pom.xml
@@ -105,6 +105,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>org.slf4j-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>net.minidev</groupId>
+                    <artifactId>json-smart</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/PropertiesBuilder.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/PropertiesBuilder.java
@@ -37,6 +37,12 @@ import java.util.Optional;
 @Deprecated
 public class PropertiesBuilder {
 
+    private static final Configuration JACKSON_CONFIGURATION = Configuration.builder()
+            .jsonProvider(new JacksonJsonProvider())
+            .mappingProvider(new JacksonMappingProvider())
+            .build()
+            .addOptions(Option.ALWAYS_RETURN_LIST);
+
     enum JsonObjState {BEFORE, IN_OBJECT, AFTER_OBJECT}
 
     private JsonObjState jsonObjState = JsonObjState.BEFORE;
@@ -44,7 +50,6 @@ public class PropertiesBuilder {
     private java.util.Map<String, Object> primitiveProperties;
     private StringBuilder jsonObjectString;
     private final ObjectMapper objectMapper;
-    private final Configuration jsonPathConfiguration;
 
     public PropertiesBuilder() {
         objectMapper = new ObjectMapper();
@@ -54,13 +59,6 @@ public class PropertiesBuilder {
         objectMapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS, true);
         objectMapper.configure(JsonParser.Feature.ALLOW_NUMERIC_LEADING_ZEROS, true);
         objectMapper.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
-
-
-
-        jsonPathConfiguration = Configuration.builder()
-                .jsonProvider(new JacksonJsonProvider())
-                .mappingProvider(new JacksonMappingProvider()).build();
-        jsonPathConfiguration.addOptions(Option.ALWAYS_RETURN_LIST);
 
         primitiveProperties = new HashMap<>();
         jsonObjectString =  new StringBuilder();
@@ -174,7 +172,7 @@ public class PropertiesBuilder {
             throw new RuleParseException("Cannot parse Json: " + jsonObjectString.toString());
         }
 
-        return new InstructionsProperties(primitiveProperties, jsonPathConfiguration);
+        return new InstructionsProperties(primitiveProperties, JACKSON_CONFIGURATION);
     }
 
     private void addProperty(final String name, final Object value, final Map<String, Object> target)

--- a/querqy-core/src/main/java/querqy/rewrite/commonrules/model/InstructionsProperties.java
+++ b/querqy-core/src/main/java/querqy/rewrite/commonrules/model/InstructionsProperties.java
@@ -20,6 +20,9 @@ package querqy.rewrite.commonrules.model;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -30,6 +33,12 @@ import java.util.Optional;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class InstructionsProperties {
 
+    private static final Configuration JACKSON_CONFIGURATION = Configuration.builder()
+            .jsonProvider(new JacksonJsonProvider())
+            .mappingProvider(new JacksonMappingProvider())
+            .build()
+            .addOptions(Option.ALWAYS_RETURN_LIST);
+
     @EqualsAndHashCode.Include private final Map<String, Object> propertyMap;
     private final DocumentContext documentContext;
 
@@ -39,7 +48,7 @@ public class InstructionsProperties {
     }
 
     public InstructionsProperties(final Map<String, Object> propertyMap) {
-        this(propertyMap, Configuration.defaultConfiguration());
+        this(propertyMap, JACKSON_CONFIGURATION);
     }
 
 

--- a/querqy-core/src/main/java/querqy/rewrite/rules/property/PropertyParser.java
+++ b/querqy-core/src/main/java/querqy/rewrite/rules/property/PropertyParser.java
@@ -30,6 +30,12 @@ import java.util.Map;
 @NoArgsConstructor(staticName = "create")
 public class PropertyParser {
 
+    private static final Configuration JACKSON_CONFIGURATION = Configuration.builder()
+            .jsonProvider(new JacksonJsonProvider())
+            .mappingProvider(new JacksonMappingProvider())
+            .build()
+            .addOptions(Option.ALWAYS_RETURN_LIST);
+
     public static final String ID = "_id";
     public static final String LOG_MESSAGE = "_log";
 
@@ -40,16 +46,6 @@ public class PropertyParser {
         propertiesWithDefaults.putIfAbsent(ID, defaultId);
         propertiesWithDefaults.putIfAbsent(LOG_MESSAGE, propertiesWithDefaults.get(ID));
 
-        return new InstructionsProperties(propertiesWithDefaults, createJsonPathConfiguration());
-    }
-
-    private Configuration createJsonPathConfiguration() {
-        final Configuration configuration = Configuration.builder()
-                .jsonProvider(new JacksonJsonProvider())
-                .mappingProvider(new JacksonMappingProvider())
-                .build();
-        configuration.addOptions(Option.ALWAYS_RETURN_LIST);
-
-        return configuration;
+        return new InstructionsProperties(propertiesWithDefaults, JACKSON_CONFIGURATION);
     }
 }


### PR DESCRIPTION
Replace Configuration.defaultConfiguration() (which requires json-smart) with a shared static Jackson-based Configuration in InstructionsProperties, PropertyParser, and PropertiesBuilder. Exclude net.minidev:json-smart from the json-path dependency in pom.xml.

Also fixes a latent bug in PropertyParser and PropertiesBuilder where the return value of addOptions() was discarded.