### PR TITLE
Fix NumberUnitRewriter failing to parse integer number. Fixes #1038

### DIFF
--- a/querqy-core/src/main/java/querqy/rewrite/contrib/NumberUnitRewriter.java
+++ b/querqy-core/src/main/java/querqy/rewrite/contrib/NumberUnitRewriter.java
@@ -183,7 +183,11 @@ public class NumberUnitRewriter extends AbstractNodeVisitor<Node> implements Que
     private BigDecimal parseNumber(final ComparableCharSequence seq, final int floatDelimiter) {
 
         if (floatDelimiter < 0) {
-            return createBigDecimal(seq.toString());
+            // Use subSequence rather than toString() directly: Term subclasses may override toString() to
+            // return a field-qualified form (e.g. "*:1") while charAt()/length() still operate on just the
+            // value. subSequence() creates a fresh object whose toString() is consistent with the character
+            // content.
+            return createBigDecimal(seq.subSequence(0, seq.length()).toString());
 
         } else if (floatDelimiter == seq.length() - 1) {
             return createBigDecimal(seq.subSequence(0, seq.length() - 1).toString());

--- a/querqy-core/src/test/java/querqy/rewrite/contrib/NumberUnitRewriterTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/contrib/NumberUnitRewriterTest.java
@@ -249,6 +249,24 @@ public class NumberUnitRewriterTest {
 
     }
 
+    @Test
+    public void testThatNumberIsCorrectlyParsedWhenTermToStringReturnsFieldQualifiedForm() {
+        NumberUnitRewriter numberUnitRewriter = new NumberUnitRewriter(numberUnitMap, numberUnitQueryCreator);
+
+        // Simulate a Term subclass that overrides toString() to return a field-qualified form (e.g. "*:1")
+        // while charAt()/length() still operate on just the value "1"
+        ComparableCharSequence seq = new ComparableCharSequenceWrapper("1") {
+            @Override
+            public String toString() {
+                return "*:1";
+            }
+        };
+
+        Optional<NumberUnitQueryInput> result = numberUnitRewriter.parseNumberAndUnit(seq);
+        assertThat(result).isNotEmpty();
+        assertThat(result.get()).isEqualTo(new NumberUnitQueryInput(new BigDecimal("1")));
+    }
+
     private ComparableCharSequence createSeq(String input) {
         return new ComparableCharSequenceWrapper(input);
     }


### PR DESCRIPTION


Term subclasses may override toString() to return a field-qualified representation (e.g. "*:1") while charAt()/length() still operate on just the value. parseNumber() was calling seq.toString() directly in the no-delimiter case, causing BigDecimal to receive an unparseable string. Using seq.subSequence(0, seq.length()).toString() instead creates a fresh object whose toString() reflects only the character content.