### PR TITLE
Revert json-smart exclusion and add test for 'in' operator (#1114)

### DIFF
--- a/querqy-core/pom.xml
+++ b/querqy-core/pom.xml
@@ -105,10 +105,6 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>org.slf4j-api</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>net.minidev</groupId>
-                    <artifactId>json-smart</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/querqy-core/src/test/java/querqy/rewrite/commonrules/model/InstructionsPropertiesTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/commonrules/model/InstructionsPropertiesTest.java
@@ -71,4 +71,24 @@ public class InstructionsPropertiesTest {
 
 
     }
+
+    @Test
+    public void testInOperatorMatches() {
+        // addresses #491
+        final Map<String, Object> props = new HashMap<>();
+        props.put("p1", 1);
+        props.put("p2", "2");
+        props.put("p3", Arrays.asList("3", 33));
+
+        final Map<String, Object> p4 = new HashMap<>();
+        p4.put("p41", "41");
+        p4.put("p42", 42);
+        props.put("p4", p4);
+
+        final InstructionsProperties instructionsProperties = new InstructionsProperties(props, Configuration.builder()
+                .jsonProvider(new JacksonJsonProvider()).mappingProvider(new JacksonMappingProvider()).build());
+
+        assertTrue(instructionsProperties.matches("$[?(@.p2 in [\"2\",\"11\"])]"));
+
+    }
 }


### PR DESCRIPTION
json-path 3.x hardcodes net.minidev.json.parser.JSONParser in ValueNodes$JsonNode.parse(), which is invoked for 'in', 'nin', 'anyof', 'noneof', and 'subsetof' filter operators. Removing the exclusion restores json-smart as a transitive dependency of json-path so these operators work correctly.

Adds testInOperatorMatches() to cover the 'in' operator use case from issue #491.