### PR TITLE
Word Break Rewriter: add a way to make compound modifier optional (#1125)

### DIFF
--- a/docs/adr/0003-optional-compound-modifier.md
+++ b/docs/adr/0003-optional-compound-modifier.md
@@ -1,0 +1,81 @@
+# ADR-0003: Optional compound modifier for the WordBreakCompoundRewriter
+
+- **Status:** Accepted
+- **Date:** 2026-07-11
+- **Area:** Querqy `WordBreakCompoundRewriter` — `querqy.rewriter.wordbreak`
+- **Relates to:** [ADR-0002](0002-dutch-decompounding-morphology.md) (Dutch decompounding morphology) — same rewriter, orthogonal concern.
+- **GitHub issue:** [#1125 — Word Break Rewriter: add a way to make modifier optional](https://github.com/querqy/querqy/issues/1125)
+
+## Context
+
+For a query token like `gasgrill`, `WordBreakCompoundRewriter.decompound()` currently expands the token into an alternative that requires **both** decompounded parts to match: `+gas +grill`. A user searching for `gasgrill` (a gas grill) might reasonably also want to see other grills (charcoal, electric, ...), which only share the head term `grill` with the query, not the modifier `gas`. Issue #1125 asks for a configurable way to make the modifier optional — `gas +grill` — so the head alone is enough to match, while documents that also match the modifier can be scored higher.
+
+### How the existing machinery is shaped (the constraint that drives this decision)
+
+- `MorphologicalWordBreaker.breakWord()` returns a `List<CharSequence[]>`. Tracing it through `Collector.collect()`, every element is constructed as `new Suggestion(new CharSequence[]{left, right}, score)` — **always exactly two entries**: `[0]` is the modifier (the part morphology strips a linker from / reconstructs), `[1]` is the head (matched verbatim against the dictionary). Nothing in `Morphology`/`SuffixGroupMorphology` recurses to produce more than one split point, so this shape is a real invariant of the current implementation, not just today's test data.
+- Both morphologies implemented so far — `GermanDecompoundingMorphology` and `DutchDecompoundingMorphology` — are right-headed (see ADR-0002 §"Context"), so the head is always the *last* array element and the modifier always the *first*. This matches the issue's own framing ("for Germanic languages, it would be the first part").
+- `WordBreakCompoundRewriter.decompound()` builds, per split candidate, a `BooleanQuery` (SHOULD, generated — an alternative to the original token) containing one `DisjunctionMaxQuery` per part, each wrapping a `Term` with `Occur.MUST`. Making a part "optional" means giving its `DisjunctionMaxQuery` `Occur.SHOULD` instead.
+- `BoostedTerm` (a `Term` subclass carrying a `float boost`) already exists and is exactly the "generated term with a custom weight" mechanism `SynonymInstruction` uses (`createTermFrom`: use `BoostedTerm` only if `boost != 1f`, otherwise a plain `Term`). Reusing it here needs no new query-model class and is already handled by `LuceneQueryBuilder`.
+
+## Decision
+
+### 1. New enum `OptionalModifierPosition { NONE, FIRST, LAST }`
+
+Lives in `querqy.rewriter.wordbreak`. `NONE` is the default and preserves today's behavior (both parts mandatory). `FIRST`/`LAST` say which index of the (always 2-element, but the code does not hard-assume this) decompounded array becomes optional:
+
+- `FIRST` — covers the Germanic case from the issue (`gas` optional, `grill` mandatory).
+- `LAST` — included even though no shipped morphology is left-headed today, because the issue explicitly asks for "first or last part", not just the Germanic case. This is genuine forward-compatibility for a future left-headed morphology, not speculative scope creep — it costs one extra enum value and one extra branch.
+
+Rejected alternative: a plain `boolean makeModifierOptional` covering only `FIRST`. Simpler, but would need a breaking API change the day a left-headed language is added, to encode something the issue already asked for in words.
+
+### 2. New `OptionalModifierConfig` record bundling position + boost, validated on construction
+
+```java
+public record OptionalModifierConfig(OptionalModifierPosition position, float boost) {
+    public OptionalModifierConfig {
+        if (position == OptionalModifierPosition.NONE && Float.compare(boost, 1f) != 0) {
+            throw new IllegalArgumentException(
+                "optionalModifierBoost must be 1.0 when optionalModifierPosition is NONE, got " + boost);
+        }
+    }
+
+    public static final OptionalModifierConfig DISABLED = new OptionalModifierConfig(OptionalModifierPosition.NONE, 1f);
+}
+```
+
+A bare `(OptionalModifierPosition, float)` pair of constructor params would allow an invalid combination — `NONE` with a non-neutral boost — to reach the rewriter. Bundling both into one record with a compact canonical constructor makes that combination unconstructable rather than something each caller (or the rewriter itself) has to remember to check. This is the same record style already used in this package (`WordBreak.java`).
+
+Default boost is `1.0f` (neutral): enabling the feature does not by itself change scoring beyond "this clause is now optional instead of required" — a document matching both parts still scores higher than one matching only the head, simply because one more clause contributes. Bumping the boost is opt-in, for deployments that want the both-parts-match case to stand out more strongly. This mirrors `SynonymInstruction`'s existing `boost == 1f` ⇒ plain `Term`, else `BoostedTerm` convention exactly.
+
+Rejected alternative for the default: a higher default (e.g. `2.0f`). Rejected because it would make enabling the feature silently change scores by a magic factor with no explicit user choice — inconsistent with every other boost-bearing construct in the codebase, which defaults to neutral.
+
+### 3. Threading through the constructors
+
+- `WordBreakCompoundRewriter`: one new trailing constructor param, `OptionalModifierConfig optionalModifierConfig`. The previous constructor signature is kept as an overload delegating with `OptionalModifierConfig.DISABLED`, so existing callers keep compiling.
+- `WordBreakCompoundRewriterFactory`: two new trailing constructor params, `String optionalModifierPosition, float optionalModifierBoost` — consistent with how `decompoundMorphologyName`/`compoundMorphologyName` are already passed as strings and parsed inside the factory. The factory parses the string (case-insensitive, `null`/empty ⇒ `NONE`, unknown value ⇒ `IllegalArgumentException`) and constructs the `OptionalModifierConfig` internally — so an invalid combination coming from YAML/JSON config surfaces as an `IllegalArgumentException` at factory-construction time, before anything reaches the rewriter. This is the same shape as `buildWordLookup`, which already turns primitive `List<String>` config into a richer `TrieMap<Boolean>` inside the factory. The previous factory signature is likewise kept as a delegating overload with `("NONE", 1.0f)`.
+
+This follows the existing precedent of `MorphologicalWordBreaker`, which has both a legacy constructor and a fuller one taking `weightMorphologicalPattern`.
+
+### 4. Scope: decompounding only
+
+`compound()` (combining two adjacent query tokens into a single compound term, and the reverse-compound-trigger path) is untouched. The issue is specifically about splitting a compound query token and softening the modifier requirement; compounding is the opposite direction and has no equivalent "modifier" to make optional in the same sense.
+
+## Consequences
+
+### Shipped in this change
+
+- `OptionalModifierPosition.java` — the new enum.
+- `OptionalModifierConfig.java` — the validating record described above.
+- `WordBreakCompoundRewriter.decompound()` — builds the per-part `Occur` and, for the optional part, a plain `Term` or `BoostedTerm` depending on `optionalModifierConfig.boost()`.
+- `WordBreakCompoundRewriter`/`WordBreakCompoundRewriterFactory` — new trailing constructor param(s) as described above, with backward-compatible overloads.
+- Tests covering: `NONE`/`DISABLED` (unchanged behavior), `FIRST` and `LAST` on a 2-element split, boost `1.0f` (plain `Term`) vs. a custom boost (`BoostedTerm`), the `NONE` + non-neutral-boost combination being rejected by `OptionalModifierConfig`, and that `compound()`/reverse-compounds are unaffected.
+
+### Trade-offs / known limitations
+
+- The enum encodes *position in the split array*, not "modifier" vs. "head" as a first-class concept — deliberately, since headedness is a property of the morphology (documented per-language in prose, e.g. ADR-0002), not something the rewriter tracks per candidate. A user configuring `LAST` against a right-headed morphology would make the *head* optional and the modifier mandatory, which is a legitimate (if unusual) configuration, not a bug — the rewriter has no way to know which morphology is "in charge" of headedness beyond what the operator configures.
+- If a future morphology ever produces splits with more than two parts, `FIRST`/`LAST` still resolve unambiguously (index `0` / index `length - 1`), but there is no way to make an interior part optional. Not addressed here since no such morphology exists yet.
+
+## References
+
+- [ADR-0002 — Dutch decompounding morphology](0002-dutch-decompounding-morphology.md)
+- `SynonymInstruction.createTermFrom` (`querqy-core/src/main/java/querqy/rewriter/commonrules/model/SynonymInstruction.java`) — precedent for the `boost == 1f` ⇒ plain `Term` else `BoostedTerm` convention.

--- a/querqy-core/src/main/java/querqy/rewriter/wordbreak/OptionalModifierConfig.java
+++ b/querqy-core/src/main/java/querqy/rewriter/wordbreak/OptionalModifierConfig.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2026 Querqy Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package querqy.rewriter.wordbreak;
+
+/**
+ * Bundles {@link OptionalModifierPosition} with the boost applied to the optional part when it matches, and
+ * rejects the combination that would be meaningless: a non-neutral boost while the feature is disabled
+ * ({@link OptionalModifierPosition#NONE}).
+ *
+ * @param position Which part of a decompounded token is optional.
+ * @param boost    The boost applied to the optional part's term when it is present. Must be {@code 1.0f} if
+ *                 {@code position} is {@link OptionalModifierPosition#NONE}.
+ */
+public record OptionalModifierConfig(OptionalModifierPosition position, float boost) {
+
+    /** The default configuration: decompounding requires all parts to match, as before this feature existed. */
+    public static final OptionalModifierConfig DISABLED = new OptionalModifierConfig(OptionalModifierPosition.NONE, 1f);
+
+    public OptionalModifierConfig {
+        if (position == null) {
+            throw new IllegalArgumentException("position must not be null");
+        }
+        if (position == OptionalModifierPosition.NONE && Float.compare(boost, 1f) != 0) {
+            throw new IllegalArgumentException(
+                    "optionalModifierBoost must be 1.0 when optionalModifierPosition is NONE, got " + boost);
+        }
+    }
+}

--- a/querqy-core/src/main/java/querqy/rewriter/wordbreak/OptionalModifierPosition.java
+++ b/querqy-core/src/main/java/querqy/rewriter/wordbreak/OptionalModifierPosition.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2026 Querqy Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package querqy.rewriter.wordbreak;
+
+/**
+ * Which part of a decompounded query token (see {@link WordBreakCompoundRewriter#decompound(querqy.model.Term)})
+ * is made optional instead of mandatory.
+ *
+ * <p>A decompounded token is split into an array of parts; {@code FIRST} and {@code LAST} refer to the position
+ * in that array, not to "modifier" vs. "head" as such - headedness is a property of the {@link Morphology} in use
+ * (see ADR-0002), not something tracked per candidate.</p>
+ */
+public enum OptionalModifierPosition {
+    /** Both parts of a decompounded token are mandatory (the historical default behavior). */
+    NONE,
+    /** The first part of a decompounded token is optional; all other parts remain mandatory. */
+    FIRST,
+    /** The last part of a decompounded token is optional; all other parts remain mandatory. */
+    LAST
+}

--- a/querqy-core/src/main/java/querqy/rewriter/wordbreak/WordBreakCompoundRewriter.java
+++ b/querqy-core/src/main/java/querqy/rewriter/wordbreak/WordBreakCompoundRewriter.java
@@ -21,6 +21,7 @@ import querqy.LowerCaseCharSequence;
 import querqy.model.AbstractNodeVisitor;
 import querqy.model.BooleanClause;
 import querqy.model.BooleanQuery;
+import querqy.model.BoostedTerm;
 import querqy.model.Clause;
 import querqy.model.DisjunctionMaxClause;
 import querqy.model.DisjunctionMaxQuery;
@@ -64,6 +65,8 @@ public class WordBreakCompoundRewriter extends AbstractNodeVisitor<Node> impleme
 
     private final TrieMap<Boolean> protectedWords;
 
+    private final OptionalModifierConfig optionalModifierConfig;
+
     /**
      * @param wordBreaker The word breaker to use
      * @param compounder The compounder to use
@@ -81,6 +84,31 @@ public class WordBreakCompoundRewriter extends AbstractNodeVisitor<Node> impleme
                                      final TrieMap<Boolean> reverseCompoundTriggerWords,
                                      final int maxDecompoundExpansions, final boolean verifyDecompoundCollation,
                                      final TrieMap<Boolean> protectedWords) {
+        this(wordBreaker, compounder, termCorpus, lowerCaseInput, alwaysAddReverseCompounds,
+                reverseCompoundTriggerWords, maxDecompoundExpansions, verifyDecompoundCollation, protectedWords,
+                OptionalModifierConfig.DISABLED);
+    }
+
+    /**
+     * @param wordBreaker The word breaker to use
+     * @param compounder The compounder to use
+     * @param termCorpus The term corpus for dictionary lookups
+     * @param lowerCaseInput Iff true, lowercase input before matching it against the term corpus.
+     * @param alwaysAddReverseCompounds Iff true, reverse shingles will be added to the query
+     * @param reverseCompoundTriggerWords Query tokens found as keys in this map will trigger the creation of a reverse compound of the surrounding tokens.
+     * @param maxDecompoundExpansions The maximum number of decompounds to add to the query
+     * @param verifyDecompoundCollation Iff true, verify that all parts of the compound cooccur in the corpus after decompounding
+     * @param protectedWords The "false-positive" set of terms that should never be split or be result of a combination
+     * @param optionalModifierConfig Which part of a decompounded token, if any, is optional rather than mandatory,
+     *                               and the boost to apply to it when present.
+     */
+    public WordBreakCompoundRewriter(final WordBreaker wordBreaker, final Compounder compounder,
+                                     final TermCorpus termCorpus,
+                                     final boolean lowerCaseInput, final boolean alwaysAddReverseCompounds,
+                                     final TrieMap<Boolean> reverseCompoundTriggerWords,
+                                     final int maxDecompoundExpansions, final boolean verifyDecompoundCollation,
+                                     final TrieMap<Boolean> protectedWords,
+                                     final OptionalModifierConfig optionalModifierConfig) {
 
         if (reverseCompoundTriggerWords == null) {
             throw new IllegalArgumentException("reverseCompoundTriggerWords must not be null");
@@ -96,6 +124,7 @@ public class WordBreakCompoundRewriter extends AbstractNodeVisitor<Node> impleme
         this.verifyDecompoundCollation = verifyDecompoundCollation;
         this.lowerCaseInput = lowerCaseInput;
         this.protectedWords = protectedWords;
+        this.optionalModifierConfig = optionalModifierConfig == null ? OptionalModifierConfig.DISABLED : optionalModifierConfig;
     }
 
     @Override
@@ -197,11 +226,17 @@ public class WordBreakCompoundRewriter extends AbstractNodeVisitor<Node> impleme
                 if (decompounded != null && decompounded.length > 0) {
 
                     final BooleanQuery bq = new BooleanQuery(term.getParent(), Clause.Occur.SHOULD, true);
+                    final int optionalIndex = optionalPartIndex(decompounded.length);
 
-                    for (final CharSequence word : decompounded) {
-                        final DisjunctionMaxQuery dmq = new DisjunctionMaxQuery(bq, Clause.Occur.MUST, true);
+                    for (int i = 0; i < decompounded.length; i++) {
+                        final CharSequence word = decompounded[i];
+                        final boolean isOptional = i == optionalIndex;
+                        final DisjunctionMaxQuery dmq = new DisjunctionMaxQuery(bq,
+                                isOptional ? Clause.Occur.SHOULD : Clause.Occur.MUST, true);
                         bq.addClause(dmq);
-                        dmq.addClause(new Term(dmq, term.getField(), word, true));
+                        dmq.addClause(isOptional
+                                ? optionalPartTerm(dmq, term.getField(), word)
+                                : new Term(dmq, term.getField(), word, true));
                     }
                     nodesToAdd.add(bq);
 
@@ -213,6 +248,29 @@ public class WordBreakCompoundRewriter extends AbstractNodeVisitor<Node> impleme
             // IO is broken, this looks serious -> throw as RTE
             throw new RuntimeException("Error decompounding " + term, e);
         }
+    }
+
+    /**
+     * @param numberOfParts The number of parts the decompounded token was split into
+     * @return The index into the decompounded parts that is optional, or -1 if none is (i.e. the feature is
+     * disabled).
+     */
+    private int optionalPartIndex(final int numberOfParts) {
+        switch (optionalModifierConfig.position()) {
+            case FIRST:
+                return 0;
+            case LAST:
+                return numberOfParts - 1;
+            default:
+                return -1;
+        }
+    }
+
+    private Term optionalPartTerm(final DisjunctionMaxQuery dmq, final String field, final CharSequence word) {
+        final float boost = optionalModifierConfig.boost();
+        return Float.compare(boost, 1f) == 0
+                ? new Term(dmq, field, word, true)
+                : new BoostedTerm(dmq, field, word, boost);
     }
 
     protected void compound(final Term term) {

--- a/querqy-core/src/main/java/querqy/rewriter/wordbreak/WordBreakCompoundRewriterFactory.java
+++ b/querqy-core/src/main/java/querqy/rewriter/wordbreak/WordBreakCompoundRewriterFactory.java
@@ -24,10 +24,12 @@ import querqy.rewrite.RewriterFactory;
 import querqy.rewrite.SearchEngineRequestAdapter;
 import querqy.trie.TrieMap;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class WordBreakCompoundRewriterFactory extends RewriterFactory {
 
@@ -42,6 +44,7 @@ public class WordBreakCompoundRewriterFactory extends RewriterFactory {
     private final Compounder compounder;
     private final TrieMap<Boolean> protectedWords;
     private final TermCorpus termCorpus;
+    private final OptionalModifierConfig optionalModifierConfig;
 
     /**
      * @param rewriterId                  The id of the rewriter
@@ -69,6 +72,44 @@ public class WordBreakCompoundRewriterFactory extends RewriterFactory {
                                             final List<String> protectedWords,
                                             final String decompoundMorphologyName,
                                             final String compoundMorphologyName) {
+        this(rewriterId, termCorpus, lowerCaseInput, minSuggestionFreq, minBreakLength, reverseCompoundTriggerWords,
+                alwaysAddReverseCompounds, maxDecompoundExpansions, verifyDecompoundCollation, protectedWords,
+                decompoundMorphologyName, compoundMorphologyName, OptionalModifierPosition.NONE.name(), 1f);
+    }
+
+    /**
+     * @param rewriterId                  The id of the rewriter
+     * @param termCorpus                  The term corpus for dictionary lookups
+     * @param lowerCaseInput              Iff true, lowercase input before matching it against the dictionary field.
+     * @param minSuggestionFreq           The minimum frequency of a suggestion in the dictionary field
+     * @param minBreakLength              The minimum word part length for decompounding
+     * @param reverseCompoundTriggerWords Query tokens in this list will trigger the creation of a reverse compound of the surrounding tokens.
+     * @param alwaysAddReverseCompounds   Iff true, reverse shingles will be added to the query
+     * @param maxDecompoundExpansions     The maximum number of decompounds to add to the query
+     * @param verifyDecompoundCollation   Iff true, verify that all parts of the compound cooccur in dictionaryField after decompounding
+     * @param protectedWords              Do not split these words
+     * @param decompoundMorphologyName    The name of decompounding morphology to use
+     * @param compoundMorphologyName      The name of compounding morphology to use
+     * @param optionalModifierPosition    Which part of a decompounded token, if any, is optional rather than
+     *                                    mandatory: one of {@link OptionalModifierPosition} (case-insensitive),
+     *                                    or {@code null}/empty for {@code NONE}.
+     * @param optionalModifierBoost       The boost applied to the optional part's term when it is present. Must
+     *                                    be {@code 1.0} if {@code optionalModifierPosition} is {@code NONE}.
+     */
+    public WordBreakCompoundRewriterFactory(final String rewriterId,
+                                            final TermCorpus termCorpus,
+                                            final boolean lowerCaseInput,
+                                            final int minSuggestionFreq,
+                                            final int minBreakLength,
+                                            final List<String> reverseCompoundTriggerWords,
+                                            final boolean alwaysAddReverseCompounds,
+                                            final int maxDecompoundExpansions,
+                                            final boolean verifyDecompoundCollation,
+                                            final List<String> protectedWords,
+                                            final String decompoundMorphologyName,
+                                            final String compoundMorphologyName,
+                                            final String optionalModifierPosition,
+                                            final float optionalModifierBoost) {
         super(rewriterId);
         if (verifyDecompoundCollation && !termCorpus.isCollationSupported()) {
             throw new IllegalArgumentException(
@@ -88,6 +129,9 @@ public class WordBreakCompoundRewriterFactory extends RewriterFactory {
         this.reverseCompoundTriggerWords = buildWordLookup(reverseCompoundTriggerWords, lowerCaseInput);
         this.protectedWords = buildWordLookup(protectedWords, lowerCaseInput);
 
+        this.optionalModifierConfig = new OptionalModifierConfig(
+                parseOptionalModifierPosition(optionalModifierPosition), optionalModifierBoost);
+
         final MorphologyProvider morphologyProvider = new MorphologyProvider();
         final Optional<Morphology> compoundMorphology = morphologyProvider.get(compoundMorphologyName);
         final Optional<Morphology> decompoundMorphology = morphologyProvider.get(decompoundMorphologyName);
@@ -101,12 +145,25 @@ public class WordBreakCompoundRewriterFactory extends RewriterFactory {
                 lowerCaseInput, minSuggestionFreq, minBreakLength, MAX_EVALUATIONS);
     }
 
+    private static OptionalModifierPosition parseOptionalModifierPosition(final String name) {
+        if (name == null || name.isEmpty()) {
+            return OptionalModifierPosition.NONE;
+        }
+        try {
+            return OptionalModifierPosition.valueOf(name.trim().toUpperCase());
+        } catch (final IllegalArgumentException e) {
+            throw new IllegalArgumentException("No such optionalModifierPosition " + name + ". Valid values: "
+                    + Arrays.stream(OptionalModifierPosition.values())
+                            .map(Enum::name).collect(Collectors.joining(", ")));
+        }
+    }
+
     @Override
     public QueryRewriter createRewriter(final ExpandedQuery input,
                                         final SearchEngineRequestAdapter searchEngineRequestAdapter) {
         return new WordBreakCompoundRewriter(wordBreaker, compounder, termCorpus,
                 lowerCaseInput, alwaysAddReverseCompounds, reverseCompoundTriggerWords, maxDecompoundExpansions,
-                verifyDecompoundCollation, protectedWords);
+                verifyDecompoundCollation, protectedWords, optionalModifierConfig);
     }
 
     @Override
@@ -128,6 +185,10 @@ public class WordBreakCompoundRewriterFactory extends RewriterFactory {
 
     public TrieMap<Boolean> getProtectedWords() {
         return protectedWords;
+    }
+
+    public OptionalModifierConfig getOptionalModifierConfig() {
+        return optionalModifierConfig;
     }
 
     private static TrieMap<Boolean> buildWordLookup(final Collection<String> words, final boolean lowerCase) {

--- a/querqy-core/src/test/java/querqy/rewriter/wordbreak/OptionalModifierConfigTest.java
+++ b/querqy-core/src/test/java/querqy/rewriter/wordbreak/OptionalModifierConfigTest.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2026 Querqy Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package querqy.rewriter.wordbreak;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class OptionalModifierConfigTest {
+
+    @Test
+    public void testDisabledConstantIsNoneWithNeutralBoost() {
+        assertEquals(OptionalModifierPosition.NONE, OptionalModifierConfig.DISABLED.position());
+        assertEquals(1f, OptionalModifierConfig.DISABLED.boost(), 0f);
+    }
+
+    @Test
+    public void testNonNeutralBoostIsAcceptedForFirst() {
+        final OptionalModifierConfig config = new OptionalModifierConfig(OptionalModifierPosition.FIRST, 2.5f);
+        assertEquals(OptionalModifierPosition.FIRST, config.position());
+        assertEquals(2.5f, config.boost(), 0f);
+    }
+
+    @Test
+    public void testNonNeutralBoostIsAcceptedForLast() {
+        final OptionalModifierConfig config = new OptionalModifierConfig(OptionalModifierPosition.LAST, 0.5f);
+        assertEquals(OptionalModifierPosition.LAST, config.position());
+        assertEquals(0.5f, config.boost(), 0f);
+    }
+
+    @Test
+    public void testNeutralBoostIsAcceptedForNone() {
+        final OptionalModifierConfig config = new OptionalModifierConfig(OptionalModifierPosition.NONE, 1f);
+        assertEquals(OptionalModifierPosition.NONE, config.position());
+    }
+
+    @Test
+    public void testNonNeutralBoostIsRejectedForNone() {
+        try {
+            new OptionalModifierConfig(OptionalModifierPosition.NONE, 2f);
+            fail("expected IllegalArgumentException");
+        } catch (final IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testNullPositionIsRejected() {
+        try {
+            new OptionalModifierConfig(null, 1f);
+            fail("expected IllegalArgumentException");
+        } catch (final IllegalArgumentException e) {
+            // expected
+        }
+    }
+}

--- a/querqy-core/src/test/java/querqy/rewriter/wordbreak/WordBreakCompoundRewriterFactoryTest.java
+++ b/querqy-core/src/test/java/querqy/rewriter/wordbreak/WordBreakCompoundRewriterFactoryTest.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -209,6 +210,63 @@ public class WordBreakCompoundRewriterFactoryTest {
                         .map(CharSequence::toString)
                         .collect(Collectors.toList()),
                 containsInAnyOrder("paddenpoel"));
+    }
+
+    @Test
+    public void testThatLegacyConstructorDisablesOptionalModifier() throws IOException {
+        final WordBreakCompoundRewriterFactory factory = new WordBreakCompoundRewriterFactory(
+                "w1", emptyCorpus(), true, 1, 1,
+                Arrays.asList("Word1", "word2"), false, 2, false,
+                Collections.emptyList(), "DEFAULT", "DEFAULT");
+
+        assertEquals(OptionalModifierConfig.DISABLED, factory.getOptionalModifierConfig());
+    }
+
+    @Test
+    public void testThatOptionalModifierPositionIsParsedCaseInsensitively() throws IOException {
+        final WordBreakCompoundRewriterFactory factory = new WordBreakCompoundRewriterFactory(
+                "w1", emptyCorpus(), true, 1, 1,
+                Arrays.asList("Word1", "word2"), false, 2, false,
+                Collections.emptyList(), "DEFAULT", "DEFAULT", "first", 2f);
+
+        assertEquals(new OptionalModifierConfig(OptionalModifierPosition.FIRST, 2f),
+                factory.getOptionalModifierConfig());
+    }
+
+    @Test
+    public void testThatNullOptionalModifierPositionDefaultsToNone() throws IOException {
+        final WordBreakCompoundRewriterFactory factory = new WordBreakCompoundRewriterFactory(
+                "w1", emptyCorpus(), true, 1, 1,
+                Arrays.asList("Word1", "word2"), false, 2, false,
+                Collections.emptyList(), "DEFAULT", "DEFAULT", null, 1f);
+
+        assertEquals(OptionalModifierConfig.DISABLED, factory.getOptionalModifierConfig());
+    }
+
+    @Test
+    public void testThatFactoryThrowsForUnknownOptionalModifierPosition() throws IOException {
+        try {
+            new WordBreakCompoundRewriterFactory(
+                    "w1", emptyCorpus(), true, 1, 1,
+                    Arrays.asList("Word1", "word2"), false, 2, false,
+                    Collections.emptyList(), "DEFAULT", "DEFAULT", "SIDEWAYS", 1f);
+            fail("expected IllegalArgumentException");
+        } catch (final IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testThatFactoryThrowsForNonNeutralBoostWithoutOptionalModifierPosition() throws IOException {
+        try {
+            new WordBreakCompoundRewriterFactory(
+                    "w1", emptyCorpus(), true, 1, 1,
+                    Arrays.asList("Word1", "word2"), false, 2, false,
+                    Collections.emptyList(), "DEFAULT", "DEFAULT", "NONE", 2f);
+            fail("expected IllegalArgumentException");
+        } catch (final IllegalArgumentException e) {
+            // expected
+        }
     }
 
     @Test

--- a/querqy-core/src/test/java/querqy/rewriter/wordbreak/WordBreakCompoundRewriterTest.java
+++ b/querqy-core/src/test/java/querqy/rewriter/wordbreak/WordBreakCompoundRewriterTest.java
@@ -21,12 +21,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import querqy.model.BooleanQuery;
+import querqy.model.BoostedTerm;
 import querqy.model.Clause;
 import querqy.model.DisjunctionMaxQuery;
 import querqy.model.EmptySearchEngineRequestAdapter;
 import querqy.model.ExpandedQuery;
 import querqy.model.Query;
 import querqy.model.StringRawQuery;
+import querqy.model.Term;
 import querqy.rewrite.RewriterOutput;
 import querqy.rewriter.wordbreak.Compounder;
 import querqy.rewriter.wordbreak.TermCorpus;
@@ -40,6 +43,8 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -113,6 +118,110 @@ public class WordBreakCompoundRewriterTest {
                         )
                 )
         );
+    }
+
+    @Test
+    public void testDecompoundWithOptionalFirstPart() throws IOException {
+        when(wordBreaker.breakWord(any(), any(), anyInt(), anyBoolean()))
+                .thenReturn(List.<CharSequence[]>of(new CharSequence[]{"w1", "w2"}));
+
+        WordBreakCompoundRewriter rewriter = new WordBreakCompoundRewriter(
+                wordBreaker, compounder, termCorpus, false, false, NO_TRIGGERWORDS, 5, false,
+                NO_PROTECTEDWORDS, new OptionalModifierConfig(OptionalModifierPosition.FIRST, 1f));
+        Query query = new Query();
+        addTerm(query, "w1w2", false);
+
+        ExpandedQuery expandedQuery = new ExpandedQuery(query);
+
+        final ExpandedQuery rewritten = rewriter.rewrite(expandedQuery, null).getExpandedQuery();
+
+        assertThat((Query) rewritten.getUserQuery(),
+                bq(
+                        dmq(
+                                term("w1w2", false),
+                                bq(
+                                        dmq(should(), term("w1", true)),
+                                        dmq(must(), term("w2", true))
+                                )
+                        )
+                )
+        );
+    }
+
+    @Test
+    public void testDecompoundWithOptionalLastPart() throws IOException {
+        when(wordBreaker.breakWord(any(), any(), anyInt(), anyBoolean()))
+                .thenReturn(List.<CharSequence[]>of(new CharSequence[]{"w1", "w2"}));
+
+        WordBreakCompoundRewriter rewriter = new WordBreakCompoundRewriter(
+                wordBreaker, compounder, termCorpus, false, false, NO_TRIGGERWORDS, 5, false,
+                NO_PROTECTEDWORDS, new OptionalModifierConfig(OptionalModifierPosition.LAST, 1f));
+        Query query = new Query();
+        addTerm(query, "w1w2", false);
+
+        ExpandedQuery expandedQuery = new ExpandedQuery(query);
+
+        final ExpandedQuery rewritten = rewriter.rewrite(expandedQuery, null).getExpandedQuery();
+
+        assertThat((Query) rewritten.getUserQuery(),
+                bq(
+                        dmq(
+                                term("w1w2", false),
+                                bq(
+                                        dmq(must(), term("w1", true)),
+                                        dmq(should(), term("w2", true))
+                                )
+                        )
+                )
+        );
+    }
+
+    @Test
+    public void testDecompoundOptionalPartIsPlainTermWhenBoostIsNeutral() throws IOException {
+        when(wordBreaker.breakWord(any(), any(), anyInt(), anyBoolean()))
+                .thenReturn(List.<CharSequence[]>of(new CharSequence[]{"w1", "w2"}));
+
+        WordBreakCompoundRewriter rewriter = new WordBreakCompoundRewriter(
+                wordBreaker, compounder, termCorpus, false, false, NO_TRIGGERWORDS, 5, false,
+                NO_PROTECTEDWORDS, new OptionalModifierConfig(OptionalModifierPosition.FIRST, 1f));
+        Query query = new Query();
+        addTerm(query, "w1w2", false);
+
+        ExpandedQuery expandedQuery = new ExpandedQuery(query);
+
+        final ExpandedQuery rewritten = rewriter.rewrite(expandedQuery, null).getExpandedQuery();
+
+        final Term optionalTerm = optionalPartTerm(rewritten);
+        assertFalse(optionalTerm instanceof BoostedTerm);
+    }
+
+    @Test
+    public void testDecompoundOptionalPartIsBoostedTermWhenBoostIsNotNeutral() throws IOException {
+        when(wordBreaker.breakWord(any(), any(), anyInt(), anyBoolean()))
+                .thenReturn(List.<CharSequence[]>of(new CharSequence[]{"w1", "w2"}));
+
+        WordBreakCompoundRewriter rewriter = new WordBreakCompoundRewriter(
+                wordBreaker, compounder, termCorpus, false, false, NO_TRIGGERWORDS, 5, false,
+                NO_PROTECTEDWORDS, new OptionalModifierConfig(OptionalModifierPosition.FIRST, 2.5f));
+        Query query = new Query();
+        addTerm(query, "w1w2", false);
+
+        ExpandedQuery expandedQuery = new ExpandedQuery(query);
+
+        final ExpandedQuery rewritten = rewriter.rewrite(expandedQuery, null).getExpandedQuery();
+
+        final Term optionalTerm = optionalPartTerm(rewritten);
+        assertTrue(optionalTerm instanceof BoostedTerm);
+        assertEquals(2.5f, ((BoostedTerm) optionalTerm).getBoost(), 0.0001f);
+    }
+
+    /** Navigates to the term for the (always first, in these tests) optional decompounded part. */
+    private Term optionalPartTerm(final ExpandedQuery rewritten) {
+        final Query userQuery = (Query) rewritten.getUserQuery();
+        final DisjunctionMaxQuery outerDmq = (DisjunctionMaxQuery) userQuery.getClauses().get(0);
+        final BooleanQuery decompoundBq = (BooleanQuery) outerDmq.getClauses().get(1);
+        final DisjunctionMaxQuery firstPartDmq = (DisjunctionMaxQuery) decompoundBq.getClauses().get(0);
+        return (Term) firstPartDmq.getClauses().get(0);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Adds `OptionalModifierPosition` (`NONE`/`FIRST`/`LAST`) and a validating `OptionalModifierConfig` record so the first or last part of a decompounded query token (e.g. `gasgrill` -> `gas`+`grill`) can be made optional instead of mandatory, with a configurable boost applied when the optional part is present.
- `WordBreakCompoundRewriter.decompound()` now builds `Occur.SHOULD` (optionally as a `BoostedTerm`) for the configured part instead of always requiring `Occur.MUST` for every part.
- New trailing constructor params on `WordBreakCompoundRewriter` and `WordBreakCompoundRewriterFactory`, with backward-compatible overloads so existing callers keep compiling.
- Design discussion recorded in `docs/adr/0003-optional-compound-modifier.md`.

Closes #1125.

## Test plan
- [x] `mvn -pl querqy-core -am test` (full module, no regressions)
- [x] `mvn -pl querqy-lucene -am test -Dtest=WordBreakCompoundRewriterIndexDistributionTest`
- [x] New unit tests: `OptionalModifierConfigTest`, plus new cases in `WordBreakCompoundRewriterTest` and `WordBreakCompoundRewriterFactoryTest` covering FIRST/LAST positions, neutral vs. boosted terms, invalid config combinations, and backward-compatible defaults.