### PR TITLE
Reject raw queries with no content after the * indicator

### DIFF
--- a/querqy-core/src/main/java/querqy/rewrite/rules/query/QuerqyQueryParser.java
+++ b/querqy-core/src/main/java/querqy/rewrite/rules/query/QuerqyQueryParser.java
@@ -79,7 +79,12 @@ public class QuerqyQueryParser {
             return parseAsParameterizedRawQuery();
 
         } else {
-            return new StringRawQuery(null, value.substring(1).trim(), occur, false);
+            final String rawQuery = value.substring(1).trim();
+            if (rawQuery.isEmpty()) {
+                throw new RuleParseException("Missing raw query after " + RAW_QUERY_INDICATOR + " in value: "
+                        + value);
+            }
+            return new StringRawQuery(null, rawQuery, occur, false);
         }
     }
 

--- a/querqy-core/src/test/java/querqy/rewrite/rules/instruction/InstructionParserTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/rules/instruction/InstructionParserTest.java
@@ -68,6 +68,18 @@ public class InstructionParserTest {
     }
 
     @Test
+    public void testThat_exceptionIsThrown_forFilterWithEmptyRawQuery() {
+        assertThrows(RuleParseException.class,
+                () -> parseInstruction(FILTER, "*"));
+    }
+
+    @Test
+    public void testThat_exceptionIsThrown_forFilterWithBlankRawQuery() {
+        assertThrows(RuleParseException.class,
+                () -> parseInstruction(FILTER, "*   "));
+    }
+
+    @Test
     public void testThat_instructionIsParsedProperly_forUpWithRawQuery() {
         assertThat(parseInstruction(UP, "* a:b")).isEqualTo(
                 new BoostInstruction(


### PR DESCRIPTION
## Summary
- `QuerqyQueryParser.parseAsRawQuery()` silently built an empty `StringRawQuery` for rules like `DOWN(50): *`, where the raw-query indicator `*` is followed by nothing (or only whitespace).
- The older, now-effectively-dead `LineParser`-based parser used to reject this case with `"Missing raw query after * in line: ..."`. That check was lost when the rule-parsing pipeline moved to `querqy.rewrite.rules.*` (used in production today by `SimpleCommonRulesRewriterFactory`).
- This restores the check: `parseAsRawQuery()` now throws `RuleParseException` when the content after `*` is blank.

Found while migrating an external consumer (SMUI) off the deprecated `SimpleCommonRulesParser` onto the newer parser pipeline — SMUI's rules.txt validation started silently accepting malformed rules that used to be rejected.

## Test plan
- [x] Added `testThat_exceptionIsThrown_forFilterWithEmptyRawQuery` and `testThat_exceptionIsThrown_forFilterWithBlankRawQuery` to `InstructionParserTest`, both asserting `RuleParseException`.
- [x] Full `querqy-core` suite: `mvn -o test` — 948 tests, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)