### PR TITLE
Remove unused ExpandedQuery parameter from RewriterFactory#createRewriter

### DIFF
--- a/querqy-core/src/main/java/querqy/explain/SnapshotRewriterFactory.java
+++ b/querqy-core/src/main/java/querqy/explain/SnapshotRewriterFactory.java
@@ -17,7 +17,6 @@
  */
 package querqy.explain;
 
-import querqy.model.ExpandedQuery;
 import querqy.rewrite.QueryRewriter;
 import querqy.rewrite.RewriterFactory;
 import querqy.rewrite.SearchEngineRequestAdapter;
@@ -38,8 +37,7 @@ public class SnapshotRewriterFactory extends RewriterFactory {
     }
 
     @Override
-    public synchronized QueryRewriter createRewriter(final ExpandedQuery input,
-                                                     final SearchEngineRequestAdapter searchEngineRequestAdapter) {
+    public synchronized QueryRewriter createRewriter(final SearchEngineRequestAdapter searchEngineRequestAdapter) {
         if (rewriter != null) {
             throw new IllegalStateException("This factory can only be used once!");
         }

--- a/querqy-core/src/main/java/querqy/rewrite/RewriteChain.java
+++ b/querqy-core/src/main/java/querqy/rewrite/RewriteChain.java
@@ -115,7 +115,7 @@ public class RewriteChain {
         }
 
         private RewriterOutput applyFactory(final RewriterFactory factory) {
-            final QueryRewriter rewriter = factory.createRewriter(expandedQuery, searchEngineRequestAdapter);
+            final QueryRewriter rewriter = factory.createRewriter(searchEngineRequestAdapter);
             return rewriter.rewrite(expandedQuery, searchEngineRequestAdapter);
         }
 

--- a/querqy-core/src/main/java/querqy/rewrite/RewriterFactory.java
+++ b/querqy-core/src/main/java/querqy/rewrite/RewriterFactory.java
@@ -20,7 +20,6 @@ package querqy.rewrite;
 import java.util.Collections;
 import java.util.Set;
 
-import querqy.model.ExpandedQuery;
 import querqy.model.Term;
 
 /**
@@ -35,12 +34,7 @@ public abstract class RewriterFactory {
         this.rewriterId = rewriterId;
     }
 
-    // TODO: ExpandedQuery input is not used by any factory
-    //  SearchEngineRequestAdapter is only used by SimpleCommonRulesRewriterFactory for the creation of SelectionStrategy.
-    //  Both parameters can be fully removed, as SearchEngineRequestAdapter is also passed to the rewriter via
-    //  QueryRewriter#rewrite
-    public abstract QueryRewriter createRewriter(ExpandedQuery input,
-                                                 SearchEngineRequestAdapter searchEngineRequestAdapter);
+    public abstract QueryRewriter createRewriter(SearchEngineRequestAdapter searchEngineRequestAdapter);
 
     /**
      * For clarity, implement {@link #getCacheableGenerableTerms()} instead of this

--- a/querqy-core/src/main/java/querqy/rewriter/NumberConcatenationRewriterFactory.java
+++ b/querqy-core/src/main/java/querqy/rewriter/NumberConcatenationRewriterFactory.java
@@ -17,7 +17,6 @@
  */
 package querqy.rewriter;
 
-import querqy.model.ExpandedQuery;
 import querqy.model.Term;
 import querqy.rewrite.QueryRewriter;
 import querqy.rewrite.RewriterFactory;
@@ -52,8 +51,7 @@ public class NumberConcatenationRewriterFactory extends RewriterFactory {
     }
 
     @Override
-    public QueryRewriter createRewriter(final ExpandedQuery input,
-                                        final SearchEngineRequestAdapter searchEngineRequestAdapter) {
+    public QueryRewriter createRewriter(final SearchEngineRequestAdapter searchEngineRequestAdapter) {
         return new NumberConcatenationRewriter(acceptGeneratedTerms, minimumLengthOfResultingQueryTerm);
     }
 

--- a/querqy-core/src/main/java/querqy/rewriter/PhraseBoostRewriterFactory.java
+++ b/querqy-core/src/main/java/querqy/rewriter/PhraseBoostRewriterFactory.java
@@ -17,7 +17,6 @@
  */
 package querqy.rewriter;
 
-import querqy.model.ExpandedQuery;
 import querqy.model.Term;
 import querqy.rewrite.QueryRewriter;
 import querqy.rewrite.RewriterFactory;
@@ -91,8 +90,7 @@ public class PhraseBoostRewriterFactory extends RewriterFactory {
     }
 
     @Override
-    public QueryRewriter createRewriter(final ExpandedQuery input,
-                                         final SearchEngineRequestAdapter searchEngineRequestAdapter) {
+    public QueryRewriter createRewriter(final SearchEngineRequestAdapter searchEngineRequestAdapter) {
         return rewriter;
     }
 

--- a/querqy-core/src/main/java/querqy/rewriter/ShingleRewriterFactory.java
+++ b/querqy-core/src/main/java/querqy/rewriter/ShingleRewriterFactory.java
@@ -17,7 +17,6 @@
  */
 package querqy.rewriter;
 
-import querqy.model.ExpandedQuery;
 import querqy.model.Term;
 import querqy.rewrite.QueryRewriter;
 import querqy.rewrite.RewriterFactory;
@@ -43,7 +42,7 @@ public class ShingleRewriterFactory extends RewriterFactory {
     }
 
     @Override
-    public QueryRewriter createRewriter(ExpandedQuery input, SearchEngineRequestAdapter searchEngineRequestAdapter) {
+    public QueryRewriter createRewriter(SearchEngineRequestAdapter searchEngineRequestAdapter) {
         return new ShingleRewriter(acceptGeneratedTerms);
     }
 

--- a/querqy-core/src/main/java/querqy/rewriter/commonrules/SimpleCommonRulesRewriterFactory.java
+++ b/querqy-core/src/main/java/querqy/rewriter/commonrules/SimpleCommonRulesRewriterFactory.java
@@ -28,7 +28,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import querqy.model.ExpandedQuery;
 import querqy.model.Term;
 import querqy.rewrite.QuerqyTemplateEngine;
 import querqy.rewrite.QueryRewriter;
@@ -170,8 +169,7 @@ public class SimpleCommonRulesRewriterFactory extends RewriterFactory {
     }
 
     @Override
-    public QueryRewriter createRewriter(final ExpandedQuery input,
-                                        final SearchEngineRequestAdapter searchEngineRequestAdapter) {
+    public QueryRewriter createRewriter(final SearchEngineRequestAdapter searchEngineRequestAdapter) {
 
         final SelectionStrategy selectionStrategy = searchEngineRequestAdapter
                 .getRequestParam(strategyParam)

--- a/querqy-core/src/main/java/querqy/rewriter/numberunit/NumberUnitRewriterFactory.java
+++ b/querqy-core/src/main/java/querqy/rewriter/numberunit/NumberUnitRewriterFactory.java
@@ -17,7 +17,6 @@
  */
 package querqy.rewriter.numberunit;
 
-import querqy.model.ExpandedQuery;
 import querqy.model.Term;
 import querqy.rewrite.QueryRewriter;
 import querqy.rewrite.RewriterFactory;
@@ -73,8 +72,7 @@ public class NumberUnitRewriterFactory extends RewriterFactory {
     }
 
     @Override
-    public QueryRewriter createRewriter(final ExpandedQuery input,
-                                        final SearchEngineRequestAdapter searchEngineRequestAdapter) {
+    public QueryRewriter createRewriter(final SearchEngineRequestAdapter searchEngineRequestAdapter) {
         return new NumberUnitRewriter(numberUnitMap, numberUnitQueryCreator);
     }
 

--- a/querqy-core/src/main/java/querqy/rewriter/regexreplace/RegexReplaceRewriterFactory.java
+++ b/querqy-core/src/main/java/querqy/rewriter/regexreplace/RegexReplaceRewriterFactory.java
@@ -17,7 +17,6 @@
  */
 package querqy.rewriter.regexreplace;
 
-import querqy.model.ExpandedQuery;
 import querqy.rewrite.QueryRewriter;
 import querqy.rewrite.RewriterFactory;
 import querqy.rewrite.SearchEngineRequestAdapter;
@@ -38,8 +37,7 @@ public class RegexReplaceRewriterFactory extends RewriterFactory {
     }
 
     @Override
-    public QueryRewriter createRewriter(final ExpandedQuery input,
-                                        final SearchEngineRequestAdapter searchEngineRequestAdapter) {
+    public QueryRewriter createRewriter(final SearchEngineRequestAdapter searchEngineRequestAdapter) {
 
         return new RegexReplaceRewriter(replacing);
     }

--- a/querqy-core/src/main/java/querqy/rewriter/replace/ReplaceRewriterFactory.java
+++ b/querqy-core/src/main/java/querqy/rewriter/replace/ReplaceRewriterFactory.java
@@ -17,7 +17,6 @@
  */
 package querqy.rewriter.replace;
 
-import querqy.model.ExpandedQuery;
 import querqy.model.Term;
 import querqy.parser.QuerqyParser;
 import querqy.rewrite.QueryRewriter;
@@ -46,7 +45,7 @@ public class ReplaceRewriterFactory extends RewriterFactory {
     }
 
     @Override
-    public QueryRewriter createRewriter(ExpandedQuery input, SearchEngineRequestAdapter searchEngineRequestAdapter) {
+    public QueryRewriter createRewriter(SearchEngineRequestAdapter searchEngineRequestAdapter) {
         return new ReplaceRewriter(sequenceLookup);
     }
 

--- a/querqy-core/src/main/java/querqy/rewriter/wordbreak/WordBreakCompoundRewriterFactory.java
+++ b/querqy-core/src/main/java/querqy/rewriter/wordbreak/WordBreakCompoundRewriterFactory.java
@@ -17,7 +17,6 @@
  */
 package querqy.rewriter.wordbreak;
 
-import querqy.model.ExpandedQuery;
 import querqy.model.Term;
 import querqy.rewrite.QueryRewriter;
 import querqy.rewrite.RewriterFactory;
@@ -159,8 +158,7 @@ public class WordBreakCompoundRewriterFactory extends RewriterFactory {
     }
 
     @Override
-    public QueryRewriter createRewriter(final ExpandedQuery input,
-                                        final SearchEngineRequestAdapter searchEngineRequestAdapter) {
+    public QueryRewriter createRewriter(final SearchEngineRequestAdapter searchEngineRequestAdapter) {
         return new WordBreakCompoundRewriter(wordBreaker, compounder, termCorpus,
                 lowerCaseInput, alwaysAddReverseCompounds, reverseCompoundTriggerWords, maxDecompoundExpansions,
                 verifyDecompoundCollation, protectedWords, optionalModifierConfig);

--- a/querqy-core/src/test/java/querqy/rewrite/RewriteChainTest.java
+++ b/querqy-core/src/test/java/querqy/rewrite/RewriteChainTest.java
@@ -67,8 +67,8 @@ public class RewriteChainTest {
 
         final InOrder inOrder = Mockito.inOrder(queryRewriter1, queryRewriter2);
 
-        verify(rewriterFactory1).createRewriter(any(), any());
-        verify(rewriterFactory2).createRewriter(any(), any());
+        verify(rewriterFactory1).createRewriter(any());
+        verify(rewriterFactory2).createRewriter(any());
 
         inOrder.verify(queryRewriter1).rewrite(any(), any());
         inOrder.verify(queryRewriter2).rewrite(any(), any());
@@ -194,8 +194,8 @@ public class RewriteChainTest {
         when(rewriterFactory1.getRewriterId()).thenReturn(id1);
         when(rewriterFactory2.getRewriterId()).thenReturn(id2);
 
-        when(rewriterFactory1.createRewriter(any(), any())).thenReturn(queryRewriter1);
-        when(rewriterFactory2.createRewriter(any(), any())).thenReturn(queryRewriter2);
+        when(rewriterFactory1.createRewriter(any())).thenReturn(queryRewriter1);
+        when(rewriterFactory2.createRewriter(any())).thenReturn(queryRewriter2);
     }
 
     private void setupRewriter() {

--- a/querqy-core/src/test/java/querqy/rewriter/PhraseBoostRewriterTest.java
+++ b/querqy-core/src/test/java/querqy/rewriter/PhraseBoostRewriterTest.java
@@ -361,7 +361,7 @@ public class PhraseBoostRewriterTest {
                 0.1f);
 
         ExpandedQuery eq = new ExpandedQuery(queryOf("A", "B", "C"));
-        RewriterOutput out = factory.createRewriter(eq, null).rewrite(eq, null);
+        RewriterOutput out = factory.createRewriter(null).rewrite(eq, null);
         assertSame(eq, out.getExpandedQuery());
 
         DisjunctionMaxQuery dmq = singleBoostDmq(out.getExpandedQuery());
@@ -373,7 +373,6 @@ public class PhraseBoostRewriterTest {
     public void testFactoryReturnsSameRewriterInstance() {
         PhraseBoostRewriterFactory factory = PhraseBoostRewriterFactory.create(
                 "id", Arrays.asList("title"), 0, null, 0, null, 0, 0.0f);
-        ExpandedQuery eq = new ExpandedQuery(queryOf("A", "B"));
-        assertSame(factory.createRewriter(eq, null), factory.createRewriter(eq, null));
+        assertSame(factory.createRewriter(null), factory.createRewriter(null));
     }
 }

--- a/querqy-core/src/test/java/querqy/rewriter/commonrules/SimpleCommonRulesRewriterFactoryTest.java
+++ b/querqy-core/src/test/java/querqy/rewriter/commonrules/SimpleCommonRulesRewriterFactoryTest.java
@@ -28,7 +28,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import querqy.model.ExpandedQuery;
 import querqy.model.Term;
 import querqy.rewrite.QueryRewriter;
 import querqy.rewrite.SearchEngineRequestAdapter;
@@ -63,9 +62,6 @@ public class SimpleCommonRulesRewriterFactoryTest {
 
     @Mock
     SelectionStrategy namedSelectionStrategy;
-
-    @Mock
-    ExpandedQuery query;
 
     @Mock
     SearchEngineRequestAdapter requestAdapter;
@@ -132,7 +128,7 @@ public class SimpleCommonRulesRewriterFactoryTest {
 
         final SimpleCommonRulesRewriterFactory factory = commonRulesFactory("input =>\n DECORATE: deco1");
 
-        final QueryRewriter rewriter = factory.createRewriter(query, requestAdapter);
+        final QueryRewriter rewriter = factory.createRewriter(requestAdapter);
         assertTrue(rewriter instanceof CommonRulesRewriter);
 
         final CommonRulesRewriter commonRulesRewriter = (CommonRulesRewriter) rewriter;
@@ -146,7 +142,7 @@ public class SimpleCommonRulesRewriterFactoryTest {
 
         final SimpleCommonRulesRewriterFactory factory = commonRulesFactory("input =>\n DECORATE: deco1");
 
-        final QueryRewriter rewriter = factory.createRewriter(query, requestAdapter);
+        final QueryRewriter rewriter = factory.createRewriter(requestAdapter);
         assertTrue(rewriter instanceof CommonRulesRewriter);
 
         final CommonRulesRewriter commonRulesRewriter = (CommonRulesRewriter) rewriter;
@@ -161,7 +157,7 @@ public class SimpleCommonRulesRewriterFactoryTest {
 
         final SimpleCommonRulesRewriterFactory factory = commonRulesFactory("input =>\n DECORATE: deco1");
 
-        factory.createRewriter(query, requestAdapter);
+        factory.createRewriter(requestAdapter);
 
     }
 

--- a/querqy-core/src/test/java/querqy/rewriter/regexreplace/RegexReplaceRewriterTest.java
+++ b/querqy-core/src/test/java/querqy/rewriter/regexreplace/RegexReplaceRewriterTest.java
@@ -48,7 +48,7 @@ public class RegexReplaceRewriterTest {
                 """);
 
         assertThat((Query) factory
-                        .createRewriter(null, null)
+                        .createRewriter(null)
                         .rewrite(query("pref abc"), new EmptySearchEngineRequestAdapter()).getExpandedQuery()
                         .getUserQuery(),
                 bq(
@@ -58,7 +58,7 @@ public class RegexReplaceRewriterTest {
         );
 
         assertThat((Query) factory
-                        .createRewriter(null, null)
+                        .createRewriter(null)
                                 .rewrite(query("abc"), new EmptySearchEngineRequestAdapter()).getExpandedQuery()
                         .getUserQuery(),
                 bq(
@@ -67,7 +67,7 @@ public class RegexReplaceRewriterTest {
         );
 
         assertThat((Query) factory
-                        .createRewriter(null, null)
+                        .createRewriter(null)
                         .rewrite(query("yxz"), new EmptySearchEngineRequestAdapter()).getExpandedQuery()
                         .getUserQuery(),
                 bq(
@@ -76,7 +76,7 @@ public class RegexReplaceRewriterTest {
         );
 
         assertThat((Query) factory
-                        .createRewriter(null, null)
+                        .createRewriter(null)
                         .rewrite(query("abc klm"), new EmptySearchEngineRequestAdapter()).getExpandedQuery()
                         .getUserQuery(),
                 bq(
@@ -86,7 +86,7 @@ public class RegexReplaceRewriterTest {
         );
 
         assertThat((Query) factory
-                        .createRewriter(null, null)
+                        .createRewriter(null)
                         .rewrite(query("abc yxz"), new EmptySearchEngineRequestAdapter()).getExpandedQuery()
                         .getUserQuery(),
                 bq(
@@ -106,7 +106,7 @@ public class RegexReplaceRewriterTest {
                 """);
 
         assertThat((Query) factory
-                        .createRewriter(null, null)
+                        .createRewriter(null)
                         .rewrite(query("abc"), new EmptySearchEngineRequestAdapter()).getExpandedQuery()
                         .getUserQuery(),
                 bq(
@@ -116,7 +116,7 @@ public class RegexReplaceRewriterTest {
         );
 
         assertThat((Query) factory
-                        .createRewriter(null, null)
+                        .createRewriter(null)
                         .rewrite(query("abc yxz"), new EmptySearchEngineRequestAdapter()).getExpandedQuery()
                         .getUserQuery(),
                 bq(
@@ -129,7 +129,7 @@ public class RegexReplaceRewriterTest {
         );
 
         assertThat((Query) factory
-                        .createRewriter(null, null)
+                        .createRewriter(null)
                         .rewrite(query("pref lmn abc 1234 567"), new EmptySearchEngineRequestAdapter()).getExpandedQuery()
                         .getUserQuery(),
                 bq(
@@ -154,7 +154,7 @@ public class RegexReplaceRewriterTest {
                 """);
 
         assertThat((Query) factory
-                        .createRewriter(null, null)
+                        .createRewriter(null)
                         .rewrite(query("a1c"), new EmptySearchEngineRequestAdapter()).getExpandedQuery()
                         .getUserQuery(),
                 bq(
@@ -163,7 +163,7 @@ public class RegexReplaceRewriterTest {
         );
 
         assertThat((Query) factory
-                        .createRewriter(null, null)
+                        .createRewriter(null)
                         .rewrite(query("d1f"), new EmptySearchEngineRequestAdapter()).getExpandedQuery()
                         .getUserQuery(),
                 bq(


### PR DESCRIPTION
## Summary

`RewriterFactory#createRewriter` carried a TODO claiming its `ExpandedQuery input` parameter is unused by every factory, and that `SearchEngineRequestAdapter` is only used by one. Verified both claims directly:

- **`ExpandedQuery input`**: checked all 9 implementations (`Shingle`, `PhraseBoost`, `NumberConcatenation`, `SimpleCommonRules`, `NumberUnit`, `RegexReplace`, `WordBreakCompound`, `Replace`, `Snapshot`) - never referenced in any body, only in the signature. Removed it from the abstract method, all 9 implementations, and the one caller (`RewriteChain`).
- **`SearchEngineRequestAdapter`**: left alone. It's still used by `SimpleCommonRulesRewriterFactory` to resolve the selection strategy at factory-creation time. Removing it (as the TODO also suggested) would mean moving that resolution into `QueryRewriter#rewrite` instead - a design change, not a mechanical cleanup, so out of scope here.

## External impact

`querqy-elasticsearch` and `querqy-opensearch` each have one test (`WordBreakCompoundRewriterFactoryTest`) calling `createRewriter(null, searchEngineRequestAdapter)` directly - note they already pass `null` for the removed parameter, corroborating it was dead. Each needs a one-line fix (drop the `null` arg) once that repo adopts a querqy-core release containing this change. Nothing to do on their end before then; their current build depends on the currently-released two-parameter signature and is unaffected by this PR.

## Test plan

- [x] Full `querqy-core` test suite green (903 tests).
- [x] Checked querqy-solr, querqy-elasticsearch, querqy-opensearch, querqy-unplugged for any other direct callers/implementors of `createRewriter` - only the two test call sites noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)