### PR TITLE
Move NumberUnitRewriter config parsing into querqy-core (#1046)

### DIFF
--- a/docs/adr/0005-move-numberunit-config-parsing-to-core.md
+++ b/docs/adr/0005-move-numberunit-config-parsing-to-core.md
@@ -1,0 +1,117 @@
+# ADR-0005: Move NumberUnitRewriter config parsing into querqy-core
+
+- **Status:** Accepted
+- **Date:** 2026-07-14
+- **Area:** Querqy core — `querqy.rewriter.numberunit`
+- **Relates to:** querqy/querqy#1046, branch `issue1046`
+
+## Context
+
+`NumberUnitRewriter` is configured via a JSON document (a list of unit/field/boost/filter
+definitions, plus a `scaleForLinearFunctions` setting). `querqy-core` only ever received the
+already-parsed result — `NumberUnitRewriterFactory`'s constructor took a
+`List<NumberUnitDefinition>` and a ready-made `NumberUnitQueryCreator`. Turning the raw JSON into
+that list (applying defaults, validating it, producing error messages) was left to each
+search-engine module.
+
+We checked all four consumers (`querqy-solr`, `querqy-elasticsearch`, `querqy-opensearch`,
+`querqy-unplugged`, checked out locally as sibling repos) and found the parsing code almost
+entirely duplicated:
+
+- `querqy-elasticsearch` and `querqy-opensearch`'s `NumberUnitConfigObject` DTOs are
+  byte-for-byte identical (only package names differ).
+- Their `NumberUnitRewriterFactory.parseConfig()`/`parseNumberUnitDefinition()`/
+  `parseUnitDefinitions()`/`parseFieldDefinitions()` methods are identical, including the same
+  ~12 hardcoded default constants (`DEFAULT_BOOST_MAX_SCORE_FOR_EXACT_MATCH = 200`,
+  `DEFAULT_FILTER_PERCENTAGE_LOWER_BOUNDARY = 20`, etc.) and the same validation rules (at least
+  one unit and one field per definition, non-blank `term`/`fieldName`, no duplicate unit terms
+  within a definition).
+- `querqy-solr`'s version is the same logic again; only the glue that extracts the JSON string
+  from Solr's config map differs.
+- `querqy-unplugged`'s version duplicates the logic once more, this time exposing the default
+  constants as overridable fields on a builder (`NumberUnitRulesDefinition`) — but the default
+  *values* it ships are identical to the other three.
+
+All four modules receive the config as a JSON **string** (the value of a `"config"` property) and
+hand it to a per-module `NumberUnitConfigObject` DTO via Jackson before mapping it onto core's
+model classes. None of them receive a pre-parsed `Map<String, Object>` for this rewriter today.
+`querqy-core` already depends on `jackson-databind` (used by
+`querqy.rewriter.commonrules.rules.property.skeleton.PropertySkeletonParser`), so reusing it here
+adds no new dependency — the JDK has no built-in JSON parser, so the realistic alternative was
+hand-rolling one for no dependency savings.
+
+There's already a precedent in core for a rewriter factory owning its config parsing outright:
+`RegexReplaceRewriterFactory` takes a raw `InputStreamReader` and parses the entire rules format
+internally via `RegexReplaceRewriterRulesParser`, throwing `IOException` on malformed input —
+callers don't pre-parse anything for it.
+
+## Decision
+
+Move config parsing fully into `NumberUnitRewriterFactory` itself, mirroring the
+`RegexReplaceRewriterFactory` precedent, rather than adding a parallel public parser class next to
+an unchanged factory:
+
+- **Breaking change** to `NumberUnitRewriterFactory`'s constructor: it now takes
+  `(String rewriterId, String config, IntFunction<NumberUnitQueryCreator> queryCreatorFactory)`
+  instead of `(String rewriterId, List<NumberUnitDefinition> numberUnitDefinitions, NumberUnitQueryCreator numberUnitQueryCreator)`.
+  The old constructor is removed, not deprecated — no core test exercised it (core's
+  `NumberUnitRewriterTest` builds `NumberUnitRewriter` directly against a hand-built `TrieMap`,
+  bypassing the factory entirely), so there is nothing in this repo to preserve compatibility
+  with. The four downstream repos adapt in their own follow-up PRs once they adopt a querqy-core
+  release containing this change.
+- The constructor parses `config` internally (new package-private
+  `NumberUnitRewriterConfigParser` + `NumberUnitConfigObject` DTO, alongside the factory in
+  `querqy.rewriter.numberunit`, same layout as `regexreplace`), applying the default constants
+  previously duplicated per-module, and throws `IOException` for malformed JSON or
+  `IllegalArgumentException` for semantic errors (missing unit/field definitions, blank
+  term/fieldName) — same split as the code it replaces.
+- `queryCreatorFactory` exists because `NumberUnitQueryCreator` construction is engine-specific
+  (e.g. `NumberUnitQueryCreatorSolr`) and needs `scaleForLinearFunctions`, which only becomes known
+  once the config has been parsed. Callers pass a factory function (e.g.
+  `scale -> new NumberUnitQueryCreatorSolr(scale)`); the constructor parses the config first, then
+  invokes the function with the resolved scale.
+- A new static `NumberUnitRewriterFactory.validateConfiguration(String config)` returns
+  `List<String>` error messages without throwing, for the pre-flight validation step search
+  engines run before actually constructing the rewriter (ported from the existing
+  `validateConfiguration()` methods, including the duplicate-unit-term check that `parse()` itself
+  does not perform).
+
+### Explicitly deferred, not bundled into this change
+
+- **Updating `querqy-solr`, `querqy-elasticsearch`, `querqy-opensearch`, `querqy-unplugged`** to
+  delete their duplicated DTOs/parsing code and call the new constructor. Those are separate
+  repositories with their own release cadences; each gets its own follow-up PR once a
+  `querqy-core` release containing this change is available.
+- **`querqy-unplugged`'s per-call-site override of default constants** (via
+  `NumberUnitRulesDefinition`). If that flexibility is still needed once `querqy-unplugged`
+  migrates, it would need to be re-added as an explicit follow-up (e.g. an optional overrides
+  parameter), scoped to that migration rather than guessed at here.
+
+## Consequences
+
+### Shipped in this change
+
+- `querqy.rewriter.numberunit.NumberUnitConfigObject` and
+  `querqy.rewriter.numberunit.NumberUnitRewriterConfigParser` added to `querqy-core`.
+- `NumberUnitRewriterFactory`'s public constructor changed (breaking); its `createRewriter()`/
+  `getCacheableGenerableTerms()` behavior is unchanged.
+- Test coverage (full/minimal/invalid config fixtures, `validateConfiguration()` cases) ported
+  from the existing per-module `*ParseConfigTest` suites into `querqy-core`.
+
+### Trade-offs
+
+- Until the four downstream repos adopt this constructor, the duplication issue #1046 describes
+  isn't actually eliminated yet — this change only makes the shared implementation available and
+  removes the old core-side entry point they'd otherwise keep building against.
+- The default constants are now fixed in core rather than overridable per call site, narrowing
+  `querqy-unplugged`'s current flexibility (see deferred item above).
+
+## References
+
+- `querqy-elasticsearch/src/main/java/querqy/elasticsearch/rewriter/NumberUnitRewriterFactory.java`
+  and `.../numberunit/NumberUnitConfigObject.java` — primary source ported from.
+- `querqy-solr/querqy-solr/src/main/java/querqy/solr/rewriter/numberunit/NumberUnitRewriterFactory.java`
+- `querqy-unplugged/library/src/main/java/querqy/rewriter/builder/NumberUnitRulesFactorBuilder.java`
+- `querqy-core/src/main/java/querqy/rewriter/regexreplace/RegexReplaceRewriterFactory.java` and
+  `RegexReplaceRewriterRulesParser.java` — the existing precedent for a rewriter factory owning
+  its own config parsing in core, followed here for package layout and exception style.

--- a/querqy-core/src/main/java/querqy/rewriter/numberunit/NumberUnitConfigObject.java
+++ b/querqy-core/src/main/java/querqy/rewriter/numberunit/NumberUnitConfigObject.java
@@ -1,0 +1,223 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2026 Querqy Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package querqy.rewriter.numberunit;
+
+import java.util.List;
+
+/**
+ * Jackson binding target for the NumberUnitRewriter's JSON configuration.
+ */
+class NumberUnitConfigObject {
+
+    private Integer scaleForLinearFunctions;
+    private List<NumberUnitDefinitionObject> numberUnitDefinitions;
+
+    public Integer getScaleForLinearFunctions() {
+        return scaleForLinearFunctions;
+    }
+
+    public void setScaleForLinearFunctions(final Integer scaleForLinearFunctions) {
+        this.scaleForLinearFunctions = scaleForLinearFunctions;
+    }
+
+    public List<NumberUnitDefinitionObject> getNumberUnitDefinitions() {
+        return numberUnitDefinitions;
+    }
+
+    public void setNumberUnitDefinitions(final List<NumberUnitDefinitionObject> numberUnitDefinitions) {
+        this.numberUnitDefinitions = numberUnitDefinitions;
+    }
+
+    public static class NumberUnitDefinitionObject {
+        private List<UnitObject> units;
+        private List<FieldObject> fields;
+        private BoostObject boost = new BoostObject();
+        private FilterObject filter = new FilterObject();
+
+        public List<UnitObject> getUnits() {
+            return units;
+        }
+
+        public void setUnits(final List<UnitObject> units) {
+            this.units = units;
+        }
+
+        public List<FieldObject> getFields() {
+            return fields;
+        }
+
+        public void setFields(final List<FieldObject> fields) {
+            this.fields = fields;
+        }
+
+        public BoostObject getBoost() {
+            return boost;
+        }
+
+        public void setBoost(final BoostObject boost) {
+            this.boost = boost;
+        }
+
+        public FilterObject getFilter() {
+            return filter;
+        }
+
+        public void setFilter(final FilterObject filter) {
+            this.filter = filter;
+        }
+    }
+
+    public static class UnitObject {
+        private String term;
+        private Float multiplier;
+
+        public String getTerm() {
+            return term;
+        }
+
+        public void setTerm(final String term) {
+            this.term = term;
+        }
+
+        public Float getMultiplier() {
+            return multiplier;
+        }
+
+        public void setMultiplier(final Float multiplier) {
+            this.multiplier = multiplier;
+        }
+    }
+
+    public static class FieldObject {
+        private String fieldName;
+        private Integer scale;
+
+        public String getFieldName() {
+            return fieldName;
+        }
+
+        public void setFieldName(final String fieldName) {
+            this.fieldName = fieldName;
+        }
+
+        public Integer getScale() {
+            return scale;
+        }
+
+        public void setScale(final Integer scale) {
+            this.scale = scale;
+        }
+    }
+
+    public static class BoostObject {
+        private Float percentageLowerBoundary;
+        private Float percentageUpperBoundary;
+        private Float percentageLowerBoundaryExactMatch;
+        private Float percentageUpperBoundaryExactMatch;
+
+        private Float minScoreAtLowerBoundary;
+        private Float minScoreAtUpperBoundary;
+        private Float maxScoreForExactMatch;
+        private Float additionalScoreForExactMatch;
+
+        public Float getPercentageLowerBoundary() {
+            return percentageLowerBoundary;
+        }
+
+        public void setPercentageLowerBoundary(final Float percentageLowerBoundary) {
+            this.percentageLowerBoundary = percentageLowerBoundary;
+        }
+
+        public Float getPercentageUpperBoundary() {
+            return percentageUpperBoundary;
+        }
+
+        public void setPercentageUpperBoundary(final Float percentageUpperBoundary) {
+            this.percentageUpperBoundary = percentageUpperBoundary;
+        }
+
+        public Float getPercentageLowerBoundaryExactMatch() {
+            return percentageLowerBoundaryExactMatch;
+        }
+
+        public void setPercentageLowerBoundaryExactMatch(final Float percentageLowerBoundaryExactMatch) {
+            this.percentageLowerBoundaryExactMatch = percentageLowerBoundaryExactMatch;
+        }
+
+        public Float getPercentageUpperBoundaryExactMatch() {
+            return percentageUpperBoundaryExactMatch;
+        }
+
+        public void setPercentageUpperBoundaryExactMatch(final Float percentageUpperBoundaryExactMatch) {
+            this.percentageUpperBoundaryExactMatch = percentageUpperBoundaryExactMatch;
+        }
+
+        public Float getMinScoreAtLowerBoundary() {
+            return minScoreAtLowerBoundary;
+        }
+
+        public void setMinScoreAtLowerBoundary(final Float minScoreAtLowerBoundary) {
+            this.minScoreAtLowerBoundary = minScoreAtLowerBoundary;
+        }
+
+        public Float getMinScoreAtUpperBoundary() {
+            return minScoreAtUpperBoundary;
+        }
+
+        public void setMinScoreAtUpperBoundary(final Float minScoreAtUpperBoundary) {
+            this.minScoreAtUpperBoundary = minScoreAtUpperBoundary;
+        }
+
+        public Float getMaxScoreForExactMatch() {
+            return maxScoreForExactMatch;
+        }
+
+        public void setMaxScoreForExactMatch(final Float maxScoreForExactMatch) {
+            this.maxScoreForExactMatch = maxScoreForExactMatch;
+        }
+
+        public Float getAdditionalScoreForExactMatch() {
+            return additionalScoreForExactMatch;
+        }
+
+        public void setAdditionalScoreForExactMatch(final Float additionalScoreForExactMatch) {
+            this.additionalScoreForExactMatch = additionalScoreForExactMatch;
+        }
+    }
+
+    public static class FilterObject {
+        private Float percentageLowerBoundary;
+        private Float percentageUpperBoundary;
+
+        public Float getPercentageLowerBoundary() {
+            return percentageLowerBoundary;
+        }
+
+        public void setPercentageLowerBoundary(final Float percentageLowerBoundary) {
+            this.percentageLowerBoundary = percentageLowerBoundary;
+        }
+
+        public Float getPercentageUpperBoundary() {
+            return percentageUpperBoundary;
+        }
+
+        public void setPercentageUpperBoundary(final Float percentageUpperBoundary) {
+            this.percentageUpperBoundary = percentageUpperBoundary;
+        }
+    }
+}

--- a/querqy-core/src/main/java/querqy/rewriter/numberunit/NumberUnitRewriterConfigParser.java
+++ b/querqy-core/src/main/java/querqy/rewriter/numberunit/NumberUnitRewriterConfigParser.java
@@ -1,0 +1,232 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2026 Querqy Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package querqy.rewriter.numberunit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import querqy.rewriter.numberunit.NumberUnitConfigObject.NumberUnitDefinitionObject;
+import querqy.rewriter.numberunit.model.FieldDefinition;
+import querqy.rewriter.numberunit.model.NumberUnitDefinition;
+import querqy.rewriter.numberunit.model.UnitDefinition;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * Parses the NumberUnitRewriter's JSON configuration into core's {@link NumberUnitDefinition} model,
+ * applying the rewriter's default values and validation rules.
+ */
+class NumberUnitRewriterConfigParser {
+
+    static final String EXCEPTION_MESSAGE = "NumberUnitRewriter not properly configured. " +
+            "At least one unit and one field need to be properly defined, e. g. \n" +
+            "{\n" +
+            "  \"numberUnitDefinitions\": [\n" +
+            "    {\n" +
+            "      \"units\": [ { \"term\": \"cm\" } ],\n" +
+            "      \"fields\": [ { \"fieldName\": \"weight\" } ]\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}\n";
+
+    private static final int DEFAULT_UNIT_MULTIPLIER = 1;
+
+    private static final int DEFAULT_SCALE_FOR_LINEAR_FUNCTIONS = 5;
+    private static final int DEFAULT_FIELD_SCALE = 0;
+
+    private static final float DEFAULT_BOOST_MAX_SCORE_FOR_EXACT_MATCH = 200;
+    private static final float DEFAULT_BOOST_MIN_SCORE_AT_UPPER_BOUNDARY = 100;
+    private static final float DEFAULT_BOOST_MIN_SCORE_AT_LOWER_BOUNDARY = 100;
+    private static final float DEFAULT_BOOST_ADDITIONAL_SCORE_FOR_EXACT_MATCH = 100;
+
+    private static final float DEFAULT_BOOST_PERCENTAGE_UPPER_BOUNDARY = 20;
+    private static final float DEFAULT_BOOST_PERCENTAGE_LOWER_BOUNDARY = 20;
+    private static final float DEFAULT_BOOST_PERCENTAGE_UPPER_BOUNDARY_EXACT_MATCH = 0;
+    private static final float DEFAULT_BOOST_PERCENTAGE_LOWER_BOUNDARY_EXACT_MATCH = 0;
+
+    private static final float DEFAULT_FILTER_PERCENTAGE_LOWER_BOUNDARY = 20;
+    private static final float DEFAULT_FILTER_PERCENTAGE_UPPER_BOUNDARY = 20;
+
+    private NumberUnitRewriterConfigParser() {
+    }
+
+    /**
+     * @throws IOException if {@code config} is not valid JSON
+     * @throws IllegalArgumentException if the parsed config does not satisfy the rewriter's
+     *         validation rules (e.g. missing unit/field definitions, blank term/fieldName)
+     */
+    static ParsedNumberUnitConfig parse(final String config) throws IOException {
+        final NumberUnitConfigObject configObject = readConfigObject(config);
+        final int scale = getOrDefaultInt(configObject::getScaleForLinearFunctions,
+                DEFAULT_SCALE_FOR_LINEAR_FUNCTIONS);
+        return new ParsedNumberUnitConfig(scale, parseNumberUnitDefinitions(configObject));
+    }
+
+    /**
+     * @return a list of human-readable error messages; empty if {@code config} is valid
+     */
+    static List<String> validate(final String config) {
+        try {
+            final List<NumberUnitDefinition> numberUnitDefinitions =
+                    parseNumberUnitDefinitions(readConfigObject(config));
+
+            return numberUnitDefinitions.stream()
+                    .filter(NumberUnitRewriterConfigParser::hasDuplicateUnitDefinition)
+                    .findFirst()
+                    .<List<String>>map(def -> Collections.singletonList(
+                            "Units must only be defined once per NumberUnitDefinition"))
+                    .orElse(Collections.emptyList());
+
+        } catch (final IOException | IllegalArgumentException e) {
+            return Collections.singletonList(e.getMessage());
+        }
+    }
+
+    private static boolean hasDuplicateUnitDefinition(final NumberUnitDefinition numberUnitDefinition) {
+        final Set<String> observedUnits = new HashSet<>();
+        for (final UnitDefinition unitDefinition : numberUnitDefinition.unitDefinitions) {
+            if (!observedUnits.add(unitDefinition.term)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static NumberUnitConfigObject readConfigObject(final String config) throws IOException {
+        return new ObjectMapper().readValue(config, NumberUnitConfigObject.class);
+    }
+
+    private static List<NumberUnitDefinition> parseNumberUnitDefinitions(final NumberUnitConfigObject configObject) {
+
+        final List<NumberUnitDefinitionObject> numberUnitDefinitionObjects = configObject.getNumberUnitDefinitions();
+
+        if (numberUnitDefinitionObjects == null || numberUnitDefinitionObjects.isEmpty()) {
+            throw new IllegalArgumentException(EXCEPTION_MESSAGE);
+        }
+
+        return numberUnitDefinitionObjects.stream()
+                .map(NumberUnitRewriterConfigParser::parseNumberUnitDefinition)
+                .collect(Collectors.toList());
+    }
+
+    private static NumberUnitDefinition parseNumberUnitDefinition(final NumberUnitDefinitionObject defObj) {
+
+        final NumberUnitDefinition.Builder builder = NumberUnitDefinition.builder()
+                .addUnits(parseUnitDefinitions(defObj))
+                .addFields(parseFieldDefinitions(defObj));
+
+        final NumberUnitConfigObject.BoostObject boost = defObj.getBoost() != null
+                ? defObj.getBoost()
+                : new NumberUnitConfigObject.BoostObject();
+
+        builder
+                .setMaxScoreForExactMatch(getOrDefaultBigDecimalForFloat(
+                        boost::getMaxScoreForExactMatch, DEFAULT_BOOST_MAX_SCORE_FOR_EXACT_MATCH))
+                .setMinScoreAtUpperBoundary(getOrDefaultBigDecimalForFloat(
+                        boost::getMinScoreAtUpperBoundary, DEFAULT_BOOST_MIN_SCORE_AT_UPPER_BOUNDARY))
+                .setMinScoreAtLowerBoundary(getOrDefaultBigDecimalForFloat(
+                        boost::getMinScoreAtLowerBoundary, DEFAULT_BOOST_MIN_SCORE_AT_LOWER_BOUNDARY))
+                .setAdditionalScoreForExactMatch(getOrDefaultBigDecimalForFloat(
+                        boost::getAdditionalScoreForExactMatch, DEFAULT_BOOST_ADDITIONAL_SCORE_FOR_EXACT_MATCH))
+                .setBoostPercentageUpperBoundary(getOrDefaultBigDecimalForFloat(
+                        boost::getPercentageUpperBoundary, DEFAULT_BOOST_PERCENTAGE_UPPER_BOUNDARY))
+                .setBoostPercentageLowerBoundary(getOrDefaultBigDecimalForFloat(
+                        boost::getPercentageLowerBoundary, DEFAULT_BOOST_PERCENTAGE_LOWER_BOUNDARY))
+                .setBoostPercentageUpperBoundaryExactMatch(getOrDefaultBigDecimalForFloat(
+                        boost::getPercentageUpperBoundaryExactMatch,
+                        DEFAULT_BOOST_PERCENTAGE_UPPER_BOUNDARY_EXACT_MATCH))
+                .setBoostPercentageLowerBoundaryExactMatch(getOrDefaultBigDecimalForFloat(
+                        boost::getPercentageLowerBoundaryExactMatch,
+                        DEFAULT_BOOST_PERCENTAGE_LOWER_BOUNDARY_EXACT_MATCH));
+
+        final NumberUnitConfigObject.FilterObject filter = defObj.getFilter() != null
+                ? defObj.getFilter()
+                : new NumberUnitConfigObject.FilterObject();
+
+        builder
+                .setFilterPercentageUpperBoundary(getOrDefaultBigDecimalForFloat(
+                        filter::getPercentageUpperBoundary, DEFAULT_FILTER_PERCENTAGE_UPPER_BOUNDARY))
+                .setFilterPercentageLowerBoundary(getOrDefaultBigDecimalForFloat(
+                        filter::getPercentageLowerBoundary, DEFAULT_FILTER_PERCENTAGE_LOWER_BOUNDARY));
+
+        return builder.build();
+    }
+
+    private static List<UnitDefinition> parseUnitDefinitions(final NumberUnitDefinitionObject numberUnitDefinitionObject) {
+        final List<NumberUnitConfigObject.UnitObject> unitObjects = numberUnitDefinitionObject.getUnits();
+        if (unitObjects == null || unitObjects.isEmpty()) {
+            throw new IllegalArgumentException(EXCEPTION_MESSAGE);
+        }
+
+        return unitObjects.stream()
+                .peek(unitObject -> {
+                    if (isBlank(unitObject.getTerm())) {
+                        throw new IllegalArgumentException("Unit definition requires a term to be defined");
+                    }
+                })
+                .map(unitObject -> new UnitDefinition(
+                        unitObject.getTerm(),
+                        getOrDefaultBigDecimalForFloat(unitObject::getMultiplier, DEFAULT_UNIT_MULTIPLIER)))
+                .collect(Collectors.toList());
+    }
+
+    private static List<FieldDefinition> parseFieldDefinitions(final NumberUnitDefinitionObject numberUnitDefinitionObject) {
+        final List<NumberUnitConfigObject.FieldObject> fieldObjects = numberUnitDefinitionObject.getFields();
+        if (fieldObjects == null || fieldObjects.isEmpty()) {
+            throw new IllegalArgumentException(EXCEPTION_MESSAGE);
+        }
+
+        return fieldObjects.stream()
+                .peek(fieldObject -> {
+                    if (isBlank(fieldObject.getFieldName())) {
+                        throw new IllegalArgumentException("Field definition requires a fieldName to be defined");
+                    }
+                })
+                .map(fieldObject -> new FieldDefinition(
+                        fieldObject.getFieldName(),
+                        getOrDefaultInt(fieldObject::getScale, DEFAULT_FIELD_SCALE)))
+                .collect(Collectors.toList());
+    }
+
+    private static BigDecimal getOrDefaultBigDecimalForFloat(final Supplier<Float> supplier, final float defaultValue) {
+        final Float value = supplier.get();
+        return value != null ? BigDecimal.valueOf(value) : BigDecimal.valueOf(defaultValue);
+    }
+
+    private static int getOrDefaultInt(final Supplier<Integer> supplier, final int defaultValue) {
+        final Integer value = supplier.get();
+        return value != null ? value : defaultValue;
+    }
+
+    private static boolean isBlank(final CharSequence cs) {
+        if (cs == null || cs.length() == 0) {
+            return true;
+        }
+        for (int i = 0; i < cs.length(); i++) {
+            if (!Character.isWhitespace(cs.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/querqy-core/src/main/java/querqy/rewriter/numberunit/NumberUnitRewriterFactory.java
+++ b/querqy-core/src/main/java/querqy/rewriter/numberunit/NumberUnitRewriterFactory.java
@@ -21,27 +21,44 @@ import querqy.model.Term;
 import querqy.rewrite.QueryRewriter;
 import querqy.rewrite.RewriterFactory;
 import querqy.rewrite.SearchEngineRequestAdapter;
-import querqy.rewriter.numberunit.NumberUnitQueryCreator;
 import querqy.rewriter.numberunit.model.NumberUnitDefinition;
 import querqy.rewriter.numberunit.model.PerUnitNumberUnitDefinition;
 import querqy.trie.State;
 import querqy.trie.TrieMap;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.IntFunction;
 
 public class NumberUnitRewriterFactory extends RewriterFactory {
 
     private final TrieMap<List<PerUnitNumberUnitDefinition>> numberUnitMap;
     private final NumberUnitQueryCreator numberUnitQueryCreator;
 
+    /**
+     * @param id                  The id of the rewriter
+     * @param config              The rewriter's JSON configuration
+     * @param queryCreatorFactory Builds the search-engine-specific {@link NumberUnitQueryCreator} from the
+     *                            {@code scaleForLinearFunctions} value parsed out of {@code config}
+     * @throws IOException if {@code config} is not valid JSON
+     * @throws IllegalArgumentException if {@code config} does not satisfy the rewriter's validation rules
+     */
     public NumberUnitRewriterFactory(final String id,
-                                     final List<NumberUnitDefinition> numberUnitDefinitions,
-                                     final NumberUnitQueryCreator numberUnitQueryCreator) {
+                                     final String config,
+                                     final IntFunction<NumberUnitQueryCreator> queryCreatorFactory) throws IOException {
         super(id);
-        this.numberUnitMap = createNumberUnitMap(numberUnitDefinitions);
-        this.numberUnitQueryCreator = numberUnitQueryCreator;
+        final ParsedNumberUnitConfig parsedConfig = NumberUnitRewriterConfigParser.parse(config);
+        this.numberUnitMap = createNumberUnitMap(parsedConfig.numberUnitDefinitions);
+        this.numberUnitQueryCreator = queryCreatorFactory.apply(parsedConfig.scaleForLinearFunctions);
+    }
+
+    /**
+     * @return a list of human-readable error messages; empty if {@code config} is valid
+     */
+    public static List<String> validateConfiguration(final String config) {
+        return NumberUnitRewriterConfigParser.validate(config);
     }
 
     private TrieMap<List<PerUnitNumberUnitDefinition>> createNumberUnitMap(

--- a/querqy-core/src/main/java/querqy/rewriter/numberunit/ParsedNumberUnitConfig.java
+++ b/querqy-core/src/main/java/querqy/rewriter/numberunit/ParsedNumberUnitConfig.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2026 Querqy Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package querqy.rewriter.numberunit;
+
+import querqy.rewriter.numberunit.model.NumberUnitDefinition;
+
+import java.util.List;
+
+class ParsedNumberUnitConfig {
+
+    final int scaleForLinearFunctions;
+    final List<NumberUnitDefinition> numberUnitDefinitions;
+
+    ParsedNumberUnitConfig(final int scaleForLinearFunctions, final List<NumberUnitDefinition> numberUnitDefinitions) {
+        this.scaleForLinearFunctions = scaleForLinearFunctions;
+        this.numberUnitDefinitions = numberUnitDefinitions;
+    }
+}

--- a/querqy-core/src/test/java/querqy/rewriter/numberunit/NumberUnitRewriterConfigParserTest.java
+++ b/querqy-core/src/test/java/querqy/rewriter/numberunit/NumberUnitRewriterConfigParserTest.java
@@ -1,0 +1,137 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2026 Querqy Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package querqy.rewriter.numberunit;
+
+import org.junit.Test;
+import querqy.rewriter.numberunit.model.NumberUnitDefinition;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class NumberUnitRewriterConfigParserTest {
+
+    private static final String BASE_PATH = "numberunit/";
+
+    @Test
+    public void testFullConfig() throws IOException {
+        final ParsedNumberUnitConfig parsedConfig = NumberUnitRewriterConfigParser.parse(
+                readConfig("number-unit-full-config.json"));
+
+        assertThat(parsedConfig.scaleForLinearFunctions).isEqualTo(1001);
+
+        final List<NumberUnitDefinition> numberUnitDefinitions = parsedConfig.numberUnitDefinitions;
+        assertThat(numberUnitDefinitions).hasSize(1);
+
+        final NumberUnitDefinition numberUnitDefinition = numberUnitDefinitions.get(0);
+
+        assertThat(numberUnitDefinition.unitDefinitions).hasSize(1);
+        assertThat(numberUnitDefinition.unitDefinitions.get(0).term).isEqualTo("term");
+        assertThat(numberUnitDefinition.unitDefinitions.get(0).multiplier.doubleValue()).isEqualTo(1002);
+
+        assertThat(numberUnitDefinition.fields).hasSize(1);
+        assertThat(numberUnitDefinition.fields.get(0).fieldName).isEqualTo("fieldName");
+        assertThat(numberUnitDefinition.fields.get(0).scale).isEqualTo(1003);
+
+        assertThat(numberUnitDefinition.maxScoreForExactMatch.doubleValue()).isEqualTo(1004);
+        assertThat(numberUnitDefinition.minScoreAtUpperBoundary.doubleValue()).isEqualTo(1005);
+        assertThat(numberUnitDefinition.minScoreAtLowerBoundary.doubleValue()).isEqualTo(1006);
+        assertThat(numberUnitDefinition.additionalScoreForExactMatch.doubleValue()).isEqualTo(1007);
+
+        assertThat(numberUnitDefinition.boostPercentageUpperBoundary.doubleValue()).isEqualTo(1008);
+        assertThat(numberUnitDefinition.boostPercentageLowerBoundary.doubleValue()).isEqualTo(1009);
+        assertThat(numberUnitDefinition.boostPercentageUpperBoundaryExactMatch.doubleValue()).isEqualTo(1010);
+        assertThat(numberUnitDefinition.boostPercentageLowerBoundaryExactMatch.doubleValue()).isEqualTo(1011);
+
+        assertThat(numberUnitDefinition.filterPercentageUpperBoundary.doubleValue()).isEqualTo(1012);
+        assertThat(numberUnitDefinition.filterPercentageLowerBoundary.doubleValue()).isEqualTo(1013);
+    }
+
+    @Test
+    public void testMinimalConfigAppliesDefaults() throws IOException {
+        final ParsedNumberUnitConfig parsedConfig = NumberUnitRewriterConfigParser.parse(
+                readConfig("number-unit-minimal-config.json"));
+
+        assertThat(parsedConfig.scaleForLinearFunctions).isEqualTo(5);
+
+        final NumberUnitDefinition numberUnitDefinition = parsedConfig.numberUnitDefinitions.get(0);
+
+        assertThat(numberUnitDefinition.unitDefinitions.get(0).term).isEqualTo("term");
+        assertThat(numberUnitDefinition.unitDefinitions.get(0).multiplier.intValue()).isEqualTo(1);
+
+        assertThat(numberUnitDefinition.fields.get(0).fieldName).isEqualTo("fieldName");
+        assertThat(numberUnitDefinition.fields.get(0).scale).isEqualTo(0);
+
+        assertThat(numberUnitDefinition.maxScoreForExactMatch.intValue()).isEqualTo(200);
+        assertThat(numberUnitDefinition.minScoreAtUpperBoundary.intValue()).isEqualTo(100);
+        assertThat(numberUnitDefinition.minScoreAtLowerBoundary.intValue()).isEqualTo(100);
+        assertThat(numberUnitDefinition.additionalScoreForExactMatch.intValue()).isEqualTo(100);
+
+        assertThat(numberUnitDefinition.boostPercentageUpperBoundary.intValue()).isEqualTo(20);
+        assertThat(numberUnitDefinition.boostPercentageLowerBoundary.intValue()).isEqualTo(20);
+        assertThat(numberUnitDefinition.boostPercentageUpperBoundaryExactMatch.intValue()).isEqualTo(0);
+        assertThat(numberUnitDefinition.boostPercentageLowerBoundaryExactMatch.intValue()).isEqualTo(0);
+
+        assertThat(numberUnitDefinition.filterPercentageUpperBoundary.intValue()).isEqualTo(20);
+        assertThat(numberUnitDefinition.filterPercentageLowerBoundary.intValue()).isEqualTo(20);
+    }
+
+    @Test
+    public void testParseThrowsOnInvalidConfig() throws IOException {
+        final String config = readConfig("number-unit-invalid-config.json");
+        assertThatThrownBy(() -> NumberUnitRewriterConfigParser.parse(config))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testValidateReturnsEmptyForValidConfig() throws IOException {
+        assertThat(NumberUnitRewriterConfigParser.validate(readConfig("number-unit-full-config.json"))).isEmpty();
+        assertThat(NumberUnitRewriterConfigParser.validate(readConfig("number-unit-minimal-config.json"))).isEmpty();
+    }
+
+    @Test
+    public void testValidateReturnsErrorForInvalidConfig() throws IOException {
+        assertThat(NumberUnitRewriterConfigParser.validate(readConfig("number-unit-invalid-config.json")))
+                .isNotEmpty();
+    }
+
+    @Test
+    public void testValidateReturnsErrorForDuplicateUnits() throws IOException {
+        assertThat(NumberUnitRewriterConfigParser.validate(readConfig("number-unit-duplicate-units-config.json")))
+                .containsExactly("Units must only be defined once per NumberUnitDefinition");
+    }
+
+    @Test
+    public void testValidateReturnsErrorForMalformedJson() {
+        assertThat(NumberUnitRewriterConfigParser.validate("not json")).isNotEmpty();
+    }
+
+    private static String readConfig(final String fileName) {
+        try (final InputStream inputStream = NumberUnitRewriterConfigParserTest.class.getClassLoader()
+                .getResourceAsStream(BASE_PATH + fileName)) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/querqy-core/src/test/java/querqy/rewriter/numberunit/NumberUnitRewriterFactoryTest.java
+++ b/querqy-core/src/test/java/querqy/rewriter/numberunit/NumberUnitRewriterFactoryTest.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2026 Querqy Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package querqy.rewriter.numberunit;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NumberUnitRewriterFactoryTest {
+
+    private static final String MINIMAL_CONFIG =
+            "{ \"numberUnitDefinitions\": [ { \"units\": [ { \"term\": \"cm\" } ], " +
+            "\"fields\": [ { \"fieldName\": \"weight\" } ] } ] }";
+
+    @Mock
+    private NumberUnitQueryCreator numberUnitQueryCreator;
+
+    @Test
+    public void testConstructorPassesParsedScaleToQueryCreatorFactory() throws IOException {
+        final String config = "{ \"scaleForLinearFunctions\": 7, \"numberUnitDefinitions\": [ " +
+                "{ \"units\": [ { \"term\": \"cm\" } ], \"fields\": [ { \"fieldName\": \"weight\" } ] } ] }";
+
+        final AtomicInteger receivedScale = new AtomicInteger(-1);
+
+        new NumberUnitRewriterFactory("rewriter_id", config, scale -> {
+            receivedScale.set(scale);
+            return numberUnitQueryCreator;
+        });
+
+        assertThat(receivedScale.get()).isEqualTo(7);
+    }
+
+    @Test
+    public void testConstructorThrowsIOExceptionForMalformedJson() {
+        assertThatThrownBy(() -> new NumberUnitRewriterFactory("rewriter_id", "not json", scale -> numberUnitQueryCreator))
+                .isInstanceOf(IOException.class);
+    }
+
+    @Test
+    public void testConstructorThrowsIllegalArgumentExceptionForInvalidConfig() {
+        final String config = "{ \"numberUnitDefinitions\": [ {} ] }";
+        assertThatThrownBy(() -> new NumberUnitRewriterFactory("rewriter_id", config, scale -> numberUnitQueryCreator))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testValidateConfigurationDelegatesToParser() {
+        assertThat(NumberUnitRewriterFactory.validateConfiguration(MINIMAL_CONFIG)).isEmpty();
+        assertThat(NumberUnitRewriterFactory.validateConfiguration("{ \"numberUnitDefinitions\": [ {} ] }"))
+                .isNotEmpty();
+    }
+}

--- a/querqy-core/src/test/resources/numberunit/number-unit-duplicate-units-config.json
+++ b/querqy-core/src/test/resources/numberunit/number-unit-duplicate-units-config.json
@@ -1,0 +1,8 @@
+{
+  "numberUnitDefinitions": [
+    {
+      "units": [ { "term": "cm" }, { "term": "cm" } ],
+      "fields": [ { "fieldName": "fieldName" } ]
+    }
+  ]
+}

--- a/querqy-core/src/test/resources/numberunit/number-unit-full-config.json
+++ b/querqy-core/src/test/resources/numberunit/number-unit-full-config.json
@@ -1,0 +1,24 @@
+{
+  "scaleForLinearFunctions": 1001,
+  "numberUnitDefinitions": [
+    {
+      "units": [ { "term": "term",     "multiplier": 1002 } ],
+      "fields": [ { "fieldName": "fieldName", "scale": 1003 } ],
+      "boost": {
+        "maxScoreForExactMatch": 1004,
+        "minScoreAtUpperBoundary": 1005,
+        "minScoreAtLowerBoundary": 1006,
+        "additionalScoreForExactMatch": 1007,
+
+        "percentageUpperBoundary": 1008,
+        "percentageLowerBoundary": 1009,
+        "percentageUpperBoundaryExactMatch": 1010,
+        "percentageLowerBoundaryExactMatch": 1011
+      },
+      "filter": {
+        "percentageUpperBoundary": 1012,
+        "percentageLowerBoundary": 1013
+      }
+    }
+  ]
+}

--- a/querqy-core/src/test/resources/numberunit/number-unit-invalid-config.json
+++ b/querqy-core/src/test/resources/numberunit/number-unit-invalid-config.json
@@ -1,0 +1,6 @@
+{
+  "numberUnitDefinitions": [
+    {
+    }
+  ]
+}

--- a/querqy-core/src/test/resources/numberunit/number-unit-minimal-config.json
+++ b/querqy-core/src/test/resources/numberunit/number-unit-minimal-config.json
@@ -1,0 +1,8 @@
+{
+  "numberUnitDefinitions": [
+    {
+      "units": [ { "term": "term" } ],
+      "fields": [ { "fieldName": "fieldName" } ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Solr, ES, OpenSearch and Unplugged each duplicated the same JSON-to-`NumberUnitDefinition` parsing, default values, and validation logic for `NumberUnitRewriter`.
- `NumberUnitRewriterFactory` now owns this itself: its constructor takes the raw JSON config plus an `IntFunction<NumberUnitQueryCreator>` and parses/validates internally, mirroring `RegexReplaceRewriterFactory`'s existing precedent for owning its own config parsing.
- This is a **breaking change** to `NumberUnitRewriterFactory`'s public constructor (no core test exercised the old one). Downstream repos (querqy-solr, querqy-elasticsearch, querqy-opensearch, querqy-unplugged) will adapt in their own follow-up PRs once they adopt a querqy-core release containing this change.
- See `docs/adr/0005-move-numberunit-config-parsing-to-core.md` for full rationale and trade-offs.

Closes #1046

## Test plan
- [x] `mvn test` passes for `querqy-core` (full suite, including checkstyle)
- [x] New unit tests: `NumberUnitRewriterConfigParserTest` (parse/validate, defaults, malformed JSON, duplicate units) and `NumberUnitRewriterFactoryTest` (constructor wiring, exception types, `validateConfiguration`)
- [x] Config fixtures ported from the downstream repos' existing `*ParseConfigTest` suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)