### PR TITLE
Add getPropertyMap() accessor to InstructionsProperties

### DIFF
--- a/querqy-core/src/main/java/querqy/rewriter/commonrules/model/InstructionsProperties.java
+++ b/querqy-core/src/main/java/querqy/rewriter/commonrules/model/InstructionsProperties.java
@@ -25,6 +25,7 @@ import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import lombok.EqualsAndHashCode;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -53,6 +54,10 @@ public class InstructionsProperties {
 
     public Optional<Object> getProperty(final String name) {
         return Optional.ofNullable(propertyMap.get(name));
+    }
+
+    public Map<String, Object> getPropertyMap() {
+        return Collections.unmodifiableMap(propertyMap);
     }
 
     public boolean matches(final String jsonPath) {

--- a/querqy-core/src/test/java/querqy/rewriter/commonrules/model/InstructionsPropertiesTest.java
+++ b/querqy-core/src/test/java/querqy/rewriter/commonrules/model/InstructionsPropertiesTest.java
@@ -47,6 +47,27 @@ public class InstructionsPropertiesTest {
     }
 
     @Test
+    public void testGetPropertyMap() {
+
+        final Map<String, Object> props = new HashMap<>();
+        props.put("p1", 1);
+        props.put("p2", "2");
+        final InstructionsProperties instructionsProperties = new InstructionsProperties(props);
+
+        assertEquals(props, instructionsProperties.getPropertyMap());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetPropertyMapIsUnmodifiable() {
+
+        final Map<String, Object> props = new HashMap<>();
+        props.put("p1", 1);
+        final InstructionsProperties instructionsProperties = new InstructionsProperties(props);
+
+        instructionsProperties.getPropertyMap().put("p2", "2");
+    }
+
+    @Test
     public void testMatches() {
 
         final Map<String, Object> props = new HashMap<>();


### PR DESCRIPTION
## Summary
- `InstructionsProperties` previously only exposed individual properties via `getProperty(name)` or boolean JSONPath queries via `matches(...)`, with no way to read the full properties map.
- Adds `getPropertyMap()`, returning an unmodifiable view of the underlying map, so callers can enumerate all custom properties from a rule's `@{...}@` block (ordering/filtering/tracking metadata) without knowing the keys in advance — e.g. when importing parsed CommonRules rules into an external data store.

## Test plan
- [x] Added `testGetPropertyMap` and `testGetPropertyMapIsUnmodifiable` to `InstructionsPropertiesTest`
- [x] `mvn -pl querqy-core -am test -Dtest=InstructionsPropertiesTest` — 5/5 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)