### PR TITLE
Ban Jackson default typing and @JsonTypeInfo via forbiddenapis

### DIFF
--- a/querqy-core/forbidden-apis/jackson-signatures.txt
+++ b/querqy-core/forbidden-apis/jackson-signatures.txt
@@ -1,0 +1,12 @@
+@defaultMessage Do not enable Jackson polymorphic default typing or type-info annotations. querqy-core's Jackson usage is deliberately restricted to fixed-POJO / no-default-typing databinding, which is what makes it safe from the classic jackson-databind gadget-chain deserialization RCE. Enabling default typing (or @JsonTypeInfo) reopens that vulnerability class.
+
+com.fasterxml.jackson.databind.ObjectMapper#enableDefaultTyping()
+com.fasterxml.jackson.databind.ObjectMapper#enableDefaultTyping(com.fasterxml.jackson.databind.ObjectMapper$DefaultTyping)
+com.fasterxml.jackson.databind.ObjectMapper#enableDefaultTyping(com.fasterxml.jackson.databind.ObjectMapper$DefaultTyping, com.fasterxml.jackson.annotation.JsonTypeInfo$As)
+com.fasterxml.jackson.databind.ObjectMapper#enableDefaultTypingAsProperty(com.fasterxml.jackson.databind.ObjectMapper$DefaultTyping, java.lang.String)
+com.fasterxml.jackson.databind.ObjectMapper#activateDefaultTyping(com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator)
+com.fasterxml.jackson.databind.ObjectMapper#activateDefaultTyping(com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator, com.fasterxml.jackson.databind.ObjectMapper$DefaultTyping)
+com.fasterxml.jackson.databind.ObjectMapper#activateDefaultTyping(com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator, com.fasterxml.jackson.databind.ObjectMapper$DefaultTyping, com.fasterxml.jackson.annotation.JsonTypeInfo$As)
+com.fasterxml.jackson.databind.ObjectMapper#activateDefaultTypingAsProperty(com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator, com.fasterxml.jackson.databind.ObjectMapper$DefaultTyping, java.lang.String)
+com.fasterxml.jackson.databind.ObjectMapper#setDefaultTyping(com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder)
+com.fasterxml.jackson.annotation.JsonTypeInfo

--- a/querqy-core/pom.xml
+++ b/querqy-core/pom.xml
@@ -185,6 +185,25 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>de.thetaphi</groupId>
+                <artifactId>forbiddenapis</artifactId>
+                <version>3.10</version>
+                <configuration>
+                    <signaturesFiles>
+                        <signaturesFile>${project.basedir}/forbidden-apis/jackson-signatures.txt</signaturesFile>
+                    </signaturesFiles>
+                    <failOnUnsupportedJava>false</failOnUnsupportedJava>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                            <goal>testCheck</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${maven-checkstyle-plugin.version}</version>


### PR DESCRIPTION
## Summary
- querqy-core's Jackson usage relies on fixed-POJO databinding with no polymorphic type resolution, avoiding the classic jackson-databind gadget-chain RCE.
- Adds the `forbiddenapis` Maven plugin to `querqy-core`, bound to the `verify` phase, banning the `enableDefaultTyping*`/`activateDefaultTyping*`/`setDefaultTyping` method family and the `@JsonTypeInfo` annotation.
- Runs automatically in the existing CI workflow (`mvn install`) across the full JDK matrix — no new CI job needed.

## Test plan
- [x] `mvn verify` passes cleanly on current code
- [x] Manually verified the check fails the build when a forbidden method call or `@JsonTypeInfo` annotation is introduced (tested with a temporary probe class, then removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)