### PR TITLE
Fix O(n^2)/O(n log n) complexity in RegexReplacing matching

### DIFF
--- a/querqy-core/src/main/java/querqy/rewriter/regexreplace/RegexReplacing.java
+++ b/querqy-core/src/main/java/querqy/rewriter/regexreplace/RegexReplacing.java
@@ -71,6 +71,14 @@ public class RegexReplacing {
 
     public record ReplacementResult(CharSequence input, String replacement) {};
 
+    /**
+     * Caps how deeply {@link #replace(CharSequence)} may recurse into the prefix/suffix
+     * surrounding a match. Without this, a query containing many regex-matchable segments
+     * could recurse until the thread's stack overflows. No legitimate query comes anywhere
+     * near this many replaceable segments.
+     */
+    private static final int MAX_REPLACEMENT_DEPTH = 256;
+
     private final RegexMap<Replacement> regexMap = new RegexMap<>();
     private final boolean ignoreCase;
     private final List<ActionLog> actionLogs;
@@ -91,13 +99,21 @@ public class RegexReplacing {
     }
 
     public Optional<ReplacementResult> replace(final CharSequence input) {
+        return replace(input, 0);
+    }
+
+    private Optional<ReplacementResult> replace(final CharSequence input, final int depth) {
+        if (depth >= MAX_REPLACEMENT_DEPTH) {
+            return Optional.empty();
+        }
+
         final CharSequence inputSeq = ignoreCase ? new LowerCaseCharSequence(input) : input;
         final Set<MatchResult<Replacement>> all = regexMap.getAll(inputSeq);
         if (all.isEmpty()) {
             return Optional.empty();
         }
 
-        return Optional.of(applyReplacement(Collections.min(all, WEIGHT_COMPARATOR), inputSeq));
+        return Optional.of(applyReplacement(Collections.min(all, WEIGHT_COMPARATOR), inputSeq, depth));
 
     }
 
@@ -110,6 +126,11 @@ public class RegexReplacing {
     }
 
     protected ReplacementResult applyReplacement(final MatchResult<Replacement> matchResult, final CharSequence input) {
+        return applyReplacement(matchResult, input, 0);
+    }
+
+    private ReplacementResult applyReplacement(final MatchResult<Replacement> matchResult, final CharSequence input,
+                                               final int depth) {
         final Map<Integer, GroupMatch> groups = adjustGroupIndexes(matchResult.groups());
         final String replacement = matchResult.value().apply(groups);
         final GroupMatch groupMatch = groups.get(0);
@@ -125,7 +146,8 @@ public class RegexReplacing {
             prefix = "";
         }
         if (!prefix.isEmpty()) {
-            prefix = replace(prefix).map(replacementResult -> replacementResult.replacement).orElse(prefix).trim();
+            prefix = replace(prefix, depth + 1).map(replacementResult -> replacementResult.replacement)
+                    .orElse(prefix).trim();
         }
 
         String result = (prefix.isEmpty() ? "" : prefix + " ") + replacement;
@@ -133,7 +155,8 @@ public class RegexReplacing {
         int matchEnd = matchStart + match.length() + 1; // incorporate whitespace
         if (matchEnd < input.length()) {
             String suffix = inputString.substring(matchEnd);
-            result += " " + replace(suffix).map(replacementResult -> replacementResult.replacement ).orElse(suffix);
+            result += " " + replace(suffix, depth + 1).map(replacementResult -> replacementResult.replacement)
+                    .orElse(suffix);
         }
 
         if (actionLogs != null) {

--- a/querqy-core/src/main/java/querqy/rewriter/regexreplace/RegexReplacing.java
+++ b/querqy-core/src/main/java/querqy/rewriter/regexreplace/RegexReplacing.java
@@ -108,21 +108,32 @@ public class RegexReplacing {
     }
 
     public Optional<ReplacementResult> replace(final CharSequence input) {
-        return replace(input, 0);
+        final CharSequence inputSeq = ignoreCase ? new LowerCaseCharSequence(input) : input;
+        final List<PositionedMatch> sortedMatches = computeSortedMatches(inputSeq);
+        return replace(inputSeq, 0, 0, sortedMatches);
     }
 
-    private Optional<ReplacementResult> replace(final CharSequence input, final int depth) {
+    /**
+     * Recursive core of {@link #replace(CharSequence)}. {@code originOffset} is the position, in
+     * the coordinates of the original top-level input that {@code sortedMatches} was computed
+     * from, that corresponds to position 0 of {@code input} - i.e. {@code input} is understood as
+     * the window {@code [originOffset, originOffset + input.length())} of that original input.
+     * This lets every recursive call reuse the single, already-computed {@code sortedMatches}
+     * (via {@link #matchesInWindow(List, int, int)}) instead of re-scanning its own substring.
+     */
+    private Optional<ReplacementResult> replace(final CharSequence input, final int depth, final int originOffset,
+                                                final List<PositionedMatch> sortedMatches) {
         if (depth >= MAX_REPLACEMENT_DEPTH) {
             return Optional.empty();
         }
 
-        final CharSequence inputSeq = ignoreCase ? new LowerCaseCharSequence(input) : input;
-        final Set<MatchResult<Replacement>> all = findAllMatches(inputSeq);
+        final Set<MatchResult<Replacement>> all = matchesInWindow(sortedMatches, originOffset, input.length());
         if (all.isEmpty()) {
             return Optional.empty();
         }
 
-        return Optional.of(applyReplacement(Collections.min(all, WEIGHT_COMPARATOR), inputSeq, depth));
+        return Optional.of(applyReplacement(Collections.min(all, WEIGHT_COMPARATOR), input, depth, originOffset,
+                sortedMatches));
 
     }
 
@@ -196,6 +207,81 @@ public class RegexReplacing {
         return new MatchResult<>(matchResult.value(), shifted);
     }
 
+    /**
+     * A match found by {@link #findAllMatches(CharSequence)}, indexed by its overall [start, end)
+     * span (the pattern's own outer wrapping group - raw group 1, before
+     * {@link #adjustGroupIndexes(Map)} is applied) so it can be located by position without
+     * re-matching.
+     */
+    private record PositionedMatch(int start, int end, MatchResult<Replacement> matchResult) {}
+
+    /**
+     * Computes every match in {@code input} once and indexes it by position, sorted by start, so
+     * that {@link #matchesInWindow(List, int, int)} can look up matches for any sub-range of
+     * {@code input} without re-running {@link #findAllMatches(CharSequence)}.
+     */
+    private List<PositionedMatch> computeSortedMatches(final CharSequence input) {
+        final Set<MatchResult<Replacement>> all = findAllMatches(input);
+        final List<PositionedMatch> positioned = new ArrayList<>(all.size());
+        for (final MatchResult<Replacement> matchResult : all) {
+            final GroupMatch whole = matchResult.groups().get(1);
+            final int start = whole.position();
+            positioned.add(new PositionedMatch(start, start + whole.match().length(), matchResult));
+        }
+        positioned.sort(Comparator.comparingInt(PositionedMatch::start));
+        return positioned;
+    }
+
+    /**
+     * Returns every match in {@code sortedMatches} that lies entirely within the window
+     * {@code [originOffset, originOffset + windowLength)}, with positions shifted to be relative
+     * to the window's own start (i.e. as if freshly computed by {@link #findAllMatches} on that
+     * window alone). A match that starts inside the window but extends past its end is excluded -
+     * it belongs to a sibling window (e.g. a longer pattern spanning past a split point chosen by
+     * an ancestor call), not this one.
+     */
+    private static Set<MatchResult<Replacement>> matchesInWindow(final List<PositionedMatch> sortedMatches,
+                                                                  final int originOffset, final int windowLength) {
+        final int windowEnd = originOffset + windowLength;
+        final Set<MatchResult<Replacement>> result = new HashSet<>();
+
+        for (int idx = lowerBound(sortedMatches, originOffset); idx < sortedMatches.size(); idx++) {
+            final PositionedMatch positioned = sortedMatches.get(idx);
+            if (positioned.start() >= windowEnd) {
+                break;
+            }
+            if (positioned.end() <= windowEnd) {
+                result.add(shiftPositions(positioned.matchResult(), -originOffset));
+            }
+        }
+
+        return result;
+    }
+
+    /** Returns the index of the first entry in {@code sortedMatches} with start >= target. */
+    private static int lowerBound(final List<PositionedMatch> sortedMatches, final int target) {
+        int lo = 0;
+        int hi = sortedMatches.size();
+        while (lo < hi) {
+            final int mid = (lo + hi) >>> 1;
+            if (sortedMatches.get(mid).start() < target) {
+                lo = mid + 1;
+            } else {
+                hi = mid;
+            }
+        }
+        return lo;
+    }
+
+    /** Counts leading characters with code point &lt;= ' ', matching {@link String#trim()}. */
+    private static int countLeadingWhitespace(final String s) {
+        int i = 0;
+        while (i < s.length() && s.charAt(i) <= ' ') {
+            i++;
+        }
+        return i;
+    }
+
     static Map<Integer, GroupMatch> adjustGroupIndexes(final Map<Integer, GroupMatch> groups) {
         final Map<Integer, GroupMatch> result = new HashMap<>();
         for (final Map.Entry<Integer, GroupMatch> entry: groups.entrySet()) {
@@ -205,11 +291,12 @@ public class RegexReplacing {
     }
 
     protected ReplacementResult applyReplacement(final MatchResult<Replacement> matchResult, final CharSequence input) {
-        return applyReplacement(matchResult, input, 0);
+        return applyReplacement(matchResult, input, 0, 0, computeSortedMatches(input));
     }
 
     private ReplacementResult applyReplacement(final MatchResult<Replacement> matchResult, final CharSequence input,
-                                               final int depth) {
+                                               final int depth, final int originOffset,
+                                               final List<PositionedMatch> sortedMatches) {
         final Map<Integer, GroupMatch> groups = adjustGroupIndexes(matchResult.groups());
         final String replacement = matchResult.value().apply(groups);
         final GroupMatch groupMatch = groups.get(0);
@@ -219,14 +306,17 @@ public class RegexReplacing {
 
         int matchStart = groupMatch.position();
         String prefix;
+        int prefixOriginOffset = originOffset;
         if (matchStart > 0) {
-            prefix = input.toString().substring(0, matchStart).trim();
+            final String rawPrefix = inputString.substring(0, matchStart);
+            prefixOriginOffset = originOffset + countLeadingWhitespace(rawPrefix);
+            prefix = rawPrefix.trim();
         } else {
             prefix = "";
         }
         if (!prefix.isEmpty()) {
-            prefix = replace(prefix, depth + 1).map(replacementResult -> replacementResult.replacement)
-                    .orElse(prefix).trim();
+            prefix = replace(prefix, depth + 1, prefixOriginOffset, sortedMatches)
+                    .map(replacementResult -> replacementResult.replacement).orElse(prefix).trim();
         }
 
         String result = (prefix.isEmpty() ? "" : prefix + " ") + replacement;
@@ -234,8 +324,8 @@ public class RegexReplacing {
         int matchEnd = matchStart + match.length() + 1; // incorporate whitespace
         if (matchEnd < input.length()) {
             String suffix = inputString.substring(matchEnd);
-            result += " " + replace(suffix, depth + 1).map(replacementResult -> replacementResult.replacement)
-                    .orElse(suffix);
+            result += " " + replace(suffix, depth + 1, originOffset + matchEnd, sortedMatches)
+                    .map(replacementResult -> replacementResult.replacement).orElse(suffix);
         }
 
         if (actionLogs != null) {

--- a/querqy-core/src/main/java/querqy/rewriter/regexreplace/RegexReplacing.java
+++ b/querqy-core/src/main/java/querqy/rewriter/regexreplace/RegexReplacing.java
@@ -25,9 +25,11 @@ import querqy.rewrite.logging.ActionLog;
 import querqy.rewrite.logging.InstructionLog;
 import querqy.rewrite.logging.MatchLog;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -79,6 +81,13 @@ public class RegexReplacing {
      */
     private static final int MAX_REPLACEMENT_DEPTH = 256;
 
+    /**
+     * Caps how many whitespace-separated tokens a single pattern match may span when searching
+     * for matches anywhere in the input (see {@link #findAllMatches(CharSequence)}). No realistic
+     * regexreplace rule needs to match more than this many consecutive tokens.
+     */
+    private static final int MAX_MATCH_SPAN_TOKENS = 32;
+
     private final RegexMap<Replacement> regexMap = new RegexMap<>();
     private final boolean ignoreCase;
     private final List<ActionLog> actionLogs;
@@ -95,7 +104,7 @@ public class RegexReplacing {
 
     public void put(final String pattern, final String replacement) {
         final String replacementString = ignoreCase ? replacement.trim().toLowerCase() : replacement.trim();
-        regexMap.put("(" + pattern + ")", Replacement.build(replacementString, addCount++), "([^ ]+ ){0,}", "( [^ ]+){0,}");
+        regexMap.put("(" + pattern + ")", Replacement.build(replacementString, addCount++));
     }
 
     public Optional<ReplacementResult> replace(final CharSequence input) {
@@ -108,7 +117,7 @@ public class RegexReplacing {
         }
 
         final CharSequence inputSeq = ignoreCase ? new LowerCaseCharSequence(input) : input;
-        final Set<MatchResult<Replacement>> all = regexMap.getAll(inputSeq);
+        final Set<MatchResult<Replacement>> all = findAllMatches(inputSeq);
         if (all.isEmpty()) {
             return Optional.empty();
         }
@@ -117,10 +126,80 @@ public class RegexReplacing {
 
     }
 
+    /**
+     * Finds every pattern match anywhere in {@code input}, aligned to whitespace token boundaries
+     * on both ends.
+     * <p>
+     * Patterns are registered as plain (unwrapped) regexes (see {@link #put(String, String)}), so
+     * {@link RegexMap#getAll(CharSequence)} only reports a match when a pattern consumes a
+     * candidate {@code CharSequence} <em>exactly</em>. To find matches anywhere in a longer input,
+     * this tokenizes the input once and tries each pattern against growing, token-aligned
+     * candidate substrings: for every token start position, it tries the substring ending at each
+     * subsequent token boundary (up to {@link #MAX_MATCH_SPAN_TOKENS} tokens ahead), keeping
+     * whatever matches. Positions in the resulting {@link MatchResult}s are shifted back to be
+     * relative to the original {@code input}.
+     */
+    private Set<MatchResult<Replacement>> findAllMatches(final CharSequence input) {
+        final List<int[]> tokens = tokenize(input);
+        final Set<MatchResult<Replacement>> results = new HashSet<>();
+
+        for (int startIdx = 0; startIdx < tokens.size(); startIdx++) {
+            final int startOffset = tokens.get(startIdx)[0];
+            final int maxEndIdx = Math.min(tokens.size(), startIdx + MAX_MATCH_SPAN_TOKENS);
+
+            for (int endIdx = startIdx; endIdx < maxEndIdx; endIdx++) {
+                final int endOffset = tokens.get(endIdx)[1];
+                final CharSequence candidate = input.subSequence(startOffset, endOffset);
+                for (final MatchResult<Replacement> matchResult : regexMap.getAll(candidate)) {
+                    results.add(shiftPositions(matchResult, startOffset));
+                }
+            }
+        }
+
+        return results;
+    }
+
+    /**
+     * Splits {@code input} into the [start, end) offsets of its maximal runs of non-space
+     * characters, treating one or more consecutive spaces as a single separator.
+     */
+    private static List<int[]> tokenize(final CharSequence input) {
+        final List<int[]> tokens = new ArrayList<>();
+        final int len = input.length();
+        int i = 0;
+        while (i < len) {
+            while (i < len && input.charAt(i) == ' ') {
+                i++;
+            }
+            if (i >= len) {
+                break;
+            }
+            final int start = i;
+            while (i < len && input.charAt(i) != ' ') {
+                i++;
+            }
+            tokens.add(new int[] {start, i});
+        }
+        return tokens;
+    }
+
+    private static MatchResult<Replacement> shiftPositions(final MatchResult<Replacement> matchResult,
+                                                            final int offset) {
+        if (offset == 0) {
+            return matchResult;
+        }
+        final Map<Integer, GroupMatch> shifted = new HashMap<>();
+        for (final Map.Entry<Integer, GroupMatch> entry : matchResult.groups().entrySet()) {
+            final GroupMatch groupMatch = entry.getValue();
+            shifted.put(entry.getKey(), new GroupMatch(groupMatch.match(), groupMatch.position() + offset));
+        }
+        return new MatchResult<>(matchResult.value(), shifted);
+    }
+
     static Map<Integer, GroupMatch> adjustGroupIndexes(final Map<Integer, GroupMatch> groups) {
         final Map<Integer, GroupMatch> result = new HashMap<>();
         for (final Map.Entry<Integer, GroupMatch> entry: groups.entrySet()) {
-            result.put(entry.getKey() - 2, entry.getValue());
+            result.put(entry.getKey() - 1, entry.getValue());
         }
         return result;
     }

--- a/querqy-core/src/test/java/querqy/rewriter/replace/RegexReplacingTest.java
+++ b/querqy-core/src/test/java/querqy/rewriter/replace/RegexReplacingTest.java
@@ -33,8 +33,6 @@ public class RegexReplacingTest {
     public void testReplacementDoesNotStackOverflowOnManySegments() {
         // A query with many independently matchable segments used to recurse once per
         // segment with no depth limit, overflowing the stack. This must complete normally.
-        // Kept well below querqy.regex's matcher performance ceiling (tracked separately)
-        // so this test isolates the recursion-depth fix.
         final RegexReplacing regexReplacing = new RegexReplacing(true, null);
         regexReplacing.put("a", "x");
 
@@ -42,6 +40,50 @@ public class RegexReplacingTest {
         final Optional<RegexReplacing.ReplacementResult> result = regexReplacing.replace(input);
 
         assertTrue(result.isPresent());
+    }
+
+    @Test(timeout = 5_000)
+    public void testReplacementScalesLinearlyWithManySegments() {
+        // Matching used to wrap every pattern in a "skip any number of leading/trailing words"
+        // regex so a single NFA simulation could find a match anywhere in the string. That
+        // caused the number of live simulation states (and so the total work) to grow with
+        // input length, making this exact scenario (a few thousand matchable segments) time
+        // out. Matching is now done by searching token-aligned candidate substrings directly,
+        // so this completes quickly.
+        final RegexReplacing regexReplacing = new RegexReplacing(true, null);
+        regexReplacing.put("a", "x");
+
+        final String input = String.join(" ", Collections.nCopies(5_000, "a"));
+        final Optional<RegexReplacing.ReplacementResult> result = regexReplacing.replace(input);
+
+        assertTrue(result.isPresent());
+    }
+
+    @Test
+    public void testPatternDoesNotMatchWithinALongerWord() {
+        // Matches must still be aligned to whole-token boundaries, not just found anywhere
+        // as a substring.
+        final RegexReplacing regexReplacing = new RegexReplacing(true, null);
+        regexReplacing.put("cat", "X");
+
+        assertNoReplacement(regexReplacing, "cats");
+        assertNoReplacement(regexReplacing, "scat");
+        assertNoReplacement(regexReplacing, "cats dog");
+    }
+
+    @Test
+    public void testReplacementToleratesIrregularWhitespace() {
+        // Tokens are found by splitting on runs of one or more spaces, so leading/trailing/
+        // repeated spaces around an otherwise-matchable token do not prevent a match.
+        final RegexReplacing regexReplacing = new RegexReplacing(true, null);
+        regexReplacing.put("cat", "x");
+
+        assertReplacement(regexReplacing, " cat", "x");
+        assertReplacement(regexReplacing, "cat  dog", "x  dog");
+    }
+
+    private static void assertNoReplacement(final RegexReplacing regexReplacing, final String input) {
+        assertTrue(regexReplacing.replace(input).isEmpty());
     }
 
     @Test

--- a/querqy-core/src/test/java/querqy/rewriter/replace/RegexReplacingTest.java
+++ b/querqy-core/src/test/java/querqy/rewriter/replace/RegexReplacingTest.java
@@ -86,6 +86,45 @@ public class RegexReplacingTest {
         assertTrue(regexReplacing.replace(input).isEmpty());
     }
 
+    @Test(timeout = 5_000)
+    public void testReplacementScalesLinearlyAcrossRecursiveSplits() {
+        // applyReplacement() used to recurse into a freshly re-scanned prefix/suffix substring
+        // after every match, which multiplied a full rescan by the recursion depth. Matches for
+        // the whole input are now computed once and looked up by position for each recursive
+        // split, so this completes quickly even for many independently matchable segments.
+        final RegexReplacing regexReplacing = new RegexReplacing(true, null);
+        regexReplacing.put("a", "x");
+
+        final String input = String.join(" ", Collections.nCopies(100_000, "a"));
+        final Optional<RegexReplacing.ReplacementResult> result = regexReplacing.replace(input);
+
+        assertTrue(result.isPresent());
+    }
+
+    @Test
+    public void testMultiTokenMatchAtRecursiveSplitBoundary() {
+        // "c" is the best (only non-overlapping) match, splitting "a b c" into the prefix
+        // window "a b". The multi-token pattern "a b" must still be found there, exercising the
+        // case where a match's end lands exactly on the (trimmed) window boundary.
+        final RegexReplacing regexReplacing = new RegexReplacing(true, null);
+        regexReplacing.put("a b", "y");
+        regexReplacing.put("c", "z");
+
+        assertReplacement(regexReplacing, "a b c", "y z");
+    }
+
+    @Test
+    public void testOverlappingCandidateAtTiedStartPositionIsNotDoubleMatched() {
+        // "a" and "a b" both start at position 0. Whichever the top-level pick is, the
+        // recursive split by position must not let a candidate spill across a split point.
+        final RegexReplacing regexReplacing = new RegexReplacing(true, null);
+        regexReplacing.put("a", "x");
+        regexReplacing.put("a b", "y");
+        regexReplacing.put("c", "z");
+
+        assertReplacement(regexReplacing, "a b c", "y z");
+    }
+
     @Test
     public void testReplacementWithoutPlaceholderConsideringCase() {
         RegexReplacing regexReplacing = new RegexReplacing(false, null);

--- a/querqy-core/src/test/java/querqy/rewriter/replace/RegexReplacingTest.java
+++ b/querqy-core/src/test/java/querqy/rewriter/replace/RegexReplacingTest.java
@@ -17,6 +17,7 @@
  */
 package querqy.rewriter.replace;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import org.junit.Test;
@@ -27,6 +28,21 @@ import querqy.rewriter.regexreplace.RegexReplacing;
 
 
 public class RegexReplacingTest {
+
+    @Test(timeout = 5_000)
+    public void testReplacementDoesNotStackOverflowOnManySegments() {
+        // A query with many independently matchable segments used to recurse once per
+        // segment with no depth limit, overflowing the stack. This must complete normally.
+        // Kept well below querqy.regex's matcher performance ceiling (tracked separately)
+        // so this test isolates the recursion-depth fix.
+        final RegexReplacing regexReplacing = new RegexReplacing(true, null);
+        regexReplacing.put("a", "x");
+
+        final String input = String.join(" ", Collections.nCopies(300, "a"));
+        final Optional<RegexReplacing.ReplacementResult> result = regexReplacing.replace(input);
+
+        assertTrue(result.isPresent());
+    }
 
     @Test
     public void testReplacementWithoutPlaceholderConsideringCase() {


### PR DESCRIPTION
## Summary

Two related complexity fixes in `RegexReplacing`, found during a security review of the regexreplace rewriter. Together with the already-merged recursion-depth cap, these close out a DoS-relevant complexity issue reachable from unauthenticated search traffic on any deployment with a `regexreplace` rewriter configured (`RegexReplaceRewriter` passes the raw user query straight into `RegexReplacing.replace()`).

- **O(n²) matcher complexity** (`43008619`): `RegexReplacing.put()` wrapped every pattern in a "skip any number of leading/trailing words" regex (`([^ ]+ ){0,}` / `( [^ ]+){0,}`) so a single NFA simulation could find a match anywhere in the input. Each possible skip-count needs its own capture-marked simulation state, and these can't be merged the way equivalent NFA states normally would, so the number of live simulation states - and the per-position work - grew linearly with input length, making matching overall O(n²).

  Fix: patterns are registered unwrapped, and `RegexReplacing` itself searches for matches by tokenizing the input once and trying each pattern against growing, token-aligned candidate substrings (capped at 32 tokens per match - no realistic rule spans more). `querqy.regex` (`NFAMatcher`, `RegexMap`, etc.) is untouched.

  Word-boundary alignment for single-token matches is preserved; matches are now tolerant of irregular whitespace (leading/trailing/repeated spaces), which the old NFA-driven wrapper happened to reject but was never a documented or tested guarantee.

- **O(n log n) / O(depth·n) recursive re-scan** (`925f4886`): `applyReplacement()` recursed into a freshly re-scanned prefix/suffix substring after every match, so a full scan happened at every recursion level - multiplying the (now linear) scan cost by the recursion depth.

  Fix: matches for the whole original input are computed exactly once, indexed by position and sorted by start. Every recursive call is now a window into that same original input, looking up applicable matches via binary search instead of re-matching. A candidate is only valid for a window if both its start and end fall inside it, so a longer pattern can't spill across a split point chosen by an ancestor call.

## Test plan

- [x] Full `querqy-core` and `querqy-lucene` suites pass (924 + 111 tests, 0 failures)
- [x] New regression tests: large-input timing bounds for both fixes, word-boundary preservation (`cat` must not match inside `cats`), whitespace-tolerance, multi-token match landing exactly on a recursive split boundary, and a tied-start-position case verified by hand-tracing before implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)