### PR TITLE
Cap digit count in NumberUnitRewriter number parsing

### DIFF
--- a/querqy-core/src/main/java/querqy/rewriter/numberunit/NumberUnitRewriter.java
+++ b/querqy-core/src/main/java/querqy/rewriter/numberunit/NumberUnitRewriter.java
@@ -43,8 +43,19 @@ import java.util.Set;
 
 public class NumberUnitRewriter extends AbstractNodeVisitor<Node> implements QueryRewriter {
 
+    /**
+     * Default cap on how many digit characters a single query term's numeric portion may contain
+     * before it is parsed into a {@link BigDecimal}. {@code BigDecimal}'s decimal-string parsing
+     * is quadratic in the number of digits, so an attacker-supplied query term consisting of a
+     * very long, unbroken run of digits could otherwise tie up a request thread for many seconds
+     * from a single, modestly-sized request. No legitimate numeric query term needs anywhere near
+     * this many digits.
+     */
+    public static final int DEFAULT_MAX_NUMBER_DIGITS = 100;
+
     private final TrieMap<List<PerUnitNumberUnitDefinition>> numberUnitMap;
     private final NumberUnitQueryCreator numberUnitQueryCreator;
+    private final int maxNumberDigits;
 
     private final Set<NumberUnitQueryInput> numberUnitQueryInputs = new HashSet<>();
     private NumberUnitQueryInput incompleteNumberUnitQueryInput = null;
@@ -55,8 +66,15 @@ public class NumberUnitRewriter extends AbstractNodeVisitor<Node> implements Que
 
     public NumberUnitRewriter(final TrieMap<List<PerUnitNumberUnitDefinition>> numberUnitMap,
                               final NumberUnitQueryCreator numberUnitQueryCreator) {
+        this(numberUnitMap, numberUnitQueryCreator, DEFAULT_MAX_NUMBER_DIGITS);
+    }
+
+    public NumberUnitRewriter(final TrieMap<List<PerUnitNumberUnitDefinition>> numberUnitMap,
+                              final NumberUnitQueryCreator numberUnitQueryCreator,
+                              final int maxNumberDigits) {
         this.numberUnitMap = numberUnitMap;
         this.numberUnitQueryCreator = numberUnitQueryCreator;
+        this.maxNumberDigits = maxNumberDigits;
     }
 
     @Override
@@ -141,6 +159,7 @@ public class NumberUnitRewriter extends AbstractNodeVisitor<Node> implements Que
 
         boolean isNumber = false;
         int floatDelimiter = -1;
+        int digitCount = 0;
 
         for (int i = 0, len = seq.length(); i < len; i++) {
 
@@ -148,6 +167,12 @@ public class NumberUnitRewriter extends AbstractNodeVisitor<Node> implements Que
 
             if (Character.isDigit(c)) {
                 isNumber = true;
+                digitCount++;
+                if (digitCount > maxNumberDigits) {
+                    // Bail out before ever parsing this into a BigDecimal: BigDecimal's
+                    // decimal-string parsing is quadratic in digit count.
+                    return Optional.empty();
+                }
 
             } else if (isFloatDelimiter(c)) {
                 if (floatDelimiter > -1) {

--- a/querqy-core/src/main/java/querqy/rewriter/numberunit/NumberUnitRewriterFactory.java
+++ b/querqy-core/src/main/java/querqy/rewriter/numberunit/NumberUnitRewriterFactory.java
@@ -36,6 +36,7 @@ public class NumberUnitRewriterFactory extends RewriterFactory {
 
     private final TrieMap<List<PerUnitNumberUnitDefinition>> numberUnitMap;
     private final NumberUnitQueryCreator numberUnitQueryCreator;
+    private final int maxNumberDigits;
 
     /**
      * @param id                  The id of the rewriter
@@ -48,10 +49,29 @@ public class NumberUnitRewriterFactory extends RewriterFactory {
     public NumberUnitRewriterFactory(final String id,
                                      final String config,
                                      final IntFunction<NumberUnitQueryCreator> queryCreatorFactory) throws IOException {
+        this(id, config, queryCreatorFactory, NumberUnitRewriter.DEFAULT_MAX_NUMBER_DIGITS);
+    }
+
+    /**
+     * @param id                  The id of the rewriter
+     * @param config              The rewriter's JSON configuration
+     * @param queryCreatorFactory Builds the search-engine-specific {@link NumberUnitQueryCreator} from the
+     *                            {@code scaleForLinearFunctions} value parsed out of {@code config}
+     * @param maxNumberDigits     Caps how many digit characters a query term's numeric portion may
+     *                            contain before it is parsed as a number - see
+     *                            {@link NumberUnitRewriter#DEFAULT_MAX_NUMBER_DIGITS}
+     * @throws IOException if {@code config} is not valid JSON
+     * @throws IllegalArgumentException if {@code config} does not satisfy the rewriter's validation rules
+     */
+    public NumberUnitRewriterFactory(final String id,
+                                     final String config,
+                                     final IntFunction<NumberUnitQueryCreator> queryCreatorFactory,
+                                     final int maxNumberDigits) throws IOException {
         super(id);
         final ParsedNumberUnitConfig parsedConfig = NumberUnitRewriterConfigParser.parse(config);
         this.numberUnitMap = createNumberUnitMap(parsedConfig.numberUnitDefinitions);
         this.numberUnitQueryCreator = queryCreatorFactory.apply(parsedConfig.scaleForLinearFunctions);
+        this.maxNumberDigits = maxNumberDigits;
     }
 
     /**
@@ -90,7 +110,7 @@ public class NumberUnitRewriterFactory extends RewriterFactory {
 
     @Override
     public QueryRewriter createRewriter(final SearchEngineRequestAdapter searchEngineRequestAdapter) {
-        return new NumberUnitRewriter(numberUnitMap, numberUnitQueryCreator);
+        return new NumberUnitRewriter(numberUnitMap, numberUnitQueryCreator, maxNumberDigits);
     }
 
     @Override

--- a/querqy-core/src/test/java/querqy/rewriter/numberunit/NumberUnitRewriterFactoryTest.java
+++ b/querqy-core/src/test/java/querqy/rewriter/numberunit/NumberUnitRewriterFactoryTest.java
@@ -21,12 +21,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import querqy.ComparableCharSequenceWrapper;
 
 import java.io.IOException;
+import java.math.RoundingMode;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NumberUnitRewriterFactoryTest {
@@ -64,6 +67,31 @@ public class NumberUnitRewriterFactoryTest {
         final String config = "{ \"numberUnitDefinitions\": [ {} ] }";
         assertThatThrownBy(() -> new NumberUnitRewriterFactory("rewriter_id", config, scale -> numberUnitQueryCreator))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testCustomMaxNumberDigitsIsPassedToRewriter() throws IOException {
+        doReturn(3).when(numberUnitQueryCreator).getScale();
+        doReturn(RoundingMode.HALF_UP).when(numberUnitQueryCreator).getRoundingMode();
+
+        final NumberUnitRewriterFactory factory = new NumberUnitRewriterFactory(
+                "rewriter_id", MINIMAL_CONFIG, scale -> numberUnitQueryCreator, 3);
+
+        final NumberUnitRewriter rewriter = (NumberUnitRewriter) factory.createRewriter(null);
+
+        assertThat(rewriter.parseNumberAndUnit(new ComparableCharSequenceWrapper("123"))).isNotEmpty();
+        assertThat(rewriter.parseNumberAndUnit(new ComparableCharSequenceWrapper("1234"))).isEmpty();
+    }
+
+    @Test
+    public void testDefaultConstructorUsesDefaultMaxNumberDigits() throws IOException {
+        final NumberUnitRewriterFactory factory = new NumberUnitRewriterFactory(
+                "rewriter_id", MINIMAL_CONFIG, scale -> numberUnitQueryCreator);
+
+        final NumberUnitRewriter rewriter = (NumberUnitRewriter) factory.createRewriter(null);
+        final String tooManyDigits = "1".repeat(NumberUnitRewriter.DEFAULT_MAX_NUMBER_DIGITS + 1);
+
+        assertThat(rewriter.parseNumberAndUnit(new ComparableCharSequenceWrapper(tooManyDigits))).isEmpty();
     }
 
     @Test

--- a/querqy-core/src/test/java/querqy/rewriter/numberunit/NumberUnitRewriterTest.java
+++ b/querqy-core/src/test/java/querqy/rewriter/numberunit/NumberUnitRewriterTest.java
@@ -267,6 +267,38 @@ public class NumberUnitRewriterTest {
         assertThat(result.get()).isEqualTo(new NumberUnitQueryInput(new BigDecimal("1")));
     }
 
+    @Test
+    public void testNumberAtDefaultDigitCapStillParses() {
+        // BigDecimal's decimal-string parsing is quadratic in digit count, so parseNumberAndUnit
+        // rejects numbers longer than NumberUnitRewriter.DEFAULT_MAX_NUMBER_DIGITS before ever
+        // constructing a BigDecimal. Exactly at the cap must still work.
+        final NumberUnitRewriter numberUnitRewriter = new NumberUnitRewriter(numberUnitMap, numberUnitQueryCreator);
+        final String maxDigits = "1".repeat(NumberUnitRewriter.DEFAULT_MAX_NUMBER_DIGITS);
+
+        final Optional<NumberUnitQueryInput> result = numberUnitRewriter.parseNumberAndUnit(createSeq(maxDigits));
+
+        assertThat(result).isNotEmpty();
+        assertThat(result.get()).isEqualTo(new NumberUnitQueryInput(new BigDecimal(maxDigits)));
+    }
+
+    @Test
+    public void testNumberOverDefaultDigitCapIsRejected() {
+        final NumberUnitRewriter numberUnitRewriter = new NumberUnitRewriter(numberUnitMap, numberUnitQueryCreator);
+        final String tooManyDigits = "1".repeat(NumberUnitRewriter.DEFAULT_MAX_NUMBER_DIGITS + 1);
+
+        assertThat(numberUnitRewriter.parseNumberAndUnit(createSeq(tooManyDigits))).isEmpty();
+        assertThat(numberUnitRewriter.parseNumberAndUnit(createSeq(tooManyDigits + "zoll"))).isEmpty();
+    }
+
+    @Test
+    public void testCustomMaxNumberDigitsIsEnforced() {
+        final NumberUnitRewriter numberUnitRewriter = new NumberUnitRewriter(numberUnitMap, numberUnitQueryCreator, 3);
+
+        assertThat(numberUnitRewriter.parseNumberAndUnit(createSeq("123"))).isNotEmpty();
+        assertThat(numberUnitRewriter.parseNumberAndUnit(createSeq("1234"))).isEmpty();
+        assertThat(numberUnitRewriter.parseNumberAndUnit(createSeq("1234zoll"))).isEmpty();
+    }
+
     private ComparableCharSequence createSeq(String input) {
         return new ComparableCharSequenceWrapper(input);
     }


### PR DESCRIPTION
## Summary

Adds a configurable cap (`maxNumberDigits`, default 100) on how many digit characters the numeric portion of a query term may contain before being parsed as a number in `NumberUnitRewriter`. No legitimate numeric query term needs anywhere near this many digits.

Configurable via a new `NumberUnitRewriterFactory` constructor overload; existing callers are unaffected and now default to 100.

## Test plan

- [x] Full `querqy-core` suite passes (929 tests, 0 failures)
- [x] New tests: default cap boundary (at/over 100 digits), custom cap via the new factory overload, default-constructor behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)