### PR TITLE
Fix querqy-core compiler warnings

### DIFF
--- a/querqy-core/src/main/java/querqy/explain/SnapshotRewriter.java
+++ b/querqy-core/src/main/java/querqy/explain/SnapshotRewriter.java
@@ -229,7 +229,7 @@ public class SnapshotRewriter implements QueryRewriter {
 
         @Override
         public Void visit(final Term term) {
-            final HashMap props = new HashMap<>();
+            final HashMap<String, Object> props = new HashMap<>();
 
             if (term instanceof BoostedTerm) {
                 props.put(PROP_BOOST, ((BoostedTerm) term).getBoost());

--- a/querqy-core/src/main/java/querqy/rewriter/commonrules/rules/property/skeleton/PropertySkeletonParser.java
+++ b/querqy-core/src/main/java/querqy/rewriter/commonrules/rules/property/skeleton/PropertySkeletonParser.java
@@ -17,8 +17,10 @@
  */
 package querqy.rewriter.commonrules.rules.property.skeleton;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.NoArgsConstructor;
@@ -32,12 +34,14 @@ import java.util.Map;
 @NoArgsConstructor(staticName = "create")
 public class PropertySkeletonParser implements SkeletonComponentParser<Map<String, Object>> {
 
-    private final ObjectMapper mapper = new ObjectMapper()
+    private final ObjectMapper mapper = new ObjectMapper(
+            JsonFactory.builder()
+                    .enable(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS)
+                    .enable(JsonReadFeature.ALLOW_LEADING_ZEROS_FOR_NUMBERS)
+                    .build())
             .configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true)
             .configure(JsonParser.Feature.ALLOW_YAML_COMMENTS, true)
             .configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true)
-            .configure(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS, true)
-            .configure(JsonParser.Feature.ALLOW_NUMERIC_LEADING_ZEROS, true)
             .configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
 
     private final Map<String, Object> properties = new HashMap<>();

--- a/querqy-core/src/main/java/querqy/rewriter/commonrules/select/PropertySorting.java
+++ b/querqy-core/src/main/java/querqy/rewriter/commonrules/select/PropertySorting.java
@@ -79,13 +79,15 @@ public class PropertySorting implements Sorting {
 
 
         @Override
+        @SuppressWarnings("unchecked") // property values are untyped rule config; comparability across
+                                        // instructions with the same property name is a runtime assumption
         public int compare(Instructions instructions1, Instructions instructions2) {
             final Optional<Object> property1 = instructions1.getProperty(propertyName);
             final Optional<Object> property2 = instructions2.getProperty(propertyName);
 
             // p1 exist, p2 doesn't -> sort p1 before p2,  TODO: always sort missing last?
             return property1.map(o1Value ->
-                    property2.map(o2Value -> ((Comparable) o1Value).compareTo(o2Value) * factor)
+                    property2.map(o2Value -> ((Comparable<Object>) o1Value).compareTo(o2Value) * factor)
                             .orElse(-1)
             ).orElseGet(() -> property2.isPresent() ? 1 : 0);
         }


### PR DESCRIPTION
## Summary

A clean `mvn clean compile` on querqy-core previously produced two compiler warnings (a third was masked and surfaced once the first was fixed). This gets it to zero warnings:

- `PropertySkeletonParser`: migrates the two `JsonParser.Feature` flags deprecated since Jackson 2.10 to their `JsonReadFeature` replacements, configured via `JsonFactory.builder()`. No behavior change.
- `SnapshotRewriter`: parameterizes a raw `HashMap`.
- `PropertySorting`: parameterizes a raw `Comparable` cast and suppresses the resulting unchecked warning, with a comment explaining why the cast is a runtime assumption (untyped rule-config property values) rather than something the type system can verify.

## Test plan

- [x] `mvn clean compile` on querqy-core: zero warnings
- [x] Full `querqy-core` and `querqy-lucene` test suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)